### PR TITLE
build: establish independent Miffan 3 release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web-ui/pnpm-lock.yaml
+
+      - name: Install web-ui dependencies
+        working-directory: web-ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test, lint, and assemble debug APKs
+        run: ./gradlew test lint assembleDebug --stacktrace

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -1,56 +1,54 @@
-name: Daily Build
+name: Nightly Build
 
 on:
-  # 每天 UTC 18:00 触发（北京时间次日 02:00），可按需修改
   schedule:
     - cron: '0 18 * * *'
-  # 也支持手动触发
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  # 检查过去 24 小时内是否有新提交，没有则跳过构建，避免重复打包
   check:
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Check for recent commits
         id: check
+        shell: bash
         run: |
-          # 手动触发时无条件构建
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # 定时触发：仅当过去 24 小时内有新提交才构建
-          if [ -n "$(git log --since='24 hours ago' --oneline)" ]; then
+          elif [ -n "$(git log --since='24 hours ago' --oneline)" ]; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_build=false" >> "$GITHUB_OUTPUT"
-            echo "过去 24 小时无新提交，跳过构建"
+            echo "No commits in the last 24 hours; skipping the nightly build."
           fi
 
   build:
     needs: check
     if: needs.check.outputs.should_build == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write   # 发布 Release 需要写权限
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: recursive # 拉取子模块
+          submodules: recursive
 
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: '17'
 
-      # web 模块的 preBuild 会执行 `pnpm run build` 构建前端，必须准备好 Node + pnpm
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -63,67 +61,85 @@ jobs:
           cache: pnpm
           cache-dependency-path: web-ui/pnpm-lock.yaml
 
-      # gradle 的 buildWebUi 任务只跑 build 不跑 install，需在此提前安装依赖
       - name: Install web-ui dependencies
         working-directory: web-ui
         run: pnpm install --frozen-lockfile
 
-      - name: Gradle cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
-      - name: Prepare signing files
+      - name: Build non-production nightly APK
+        run: ./gradlew assembleNightly --stacktrace
+
+      - name: Verify nightly isolation
+        id: stage
+        shell: bash
         env:
-          KEY_BASE64: ${{ secrets.KEY_BASE64 }}
-          SIGNING_CONFIG: ${{ secrets.SIGNING_CONFIG }}
+          PRODUCTION_CERT_SHA256: 6C4B841AD2EF148C888D38411F0268C6C6FA908B5E0D009EA187BFAF2F1F9D31
         run: |
-          if [ -z "$KEY_BASE64" ] || [ -z "$SIGNING_CONFIG" ]; then
-            echo "Miffan release signing secrets are not configured" >&2
-            exit 1
-          fi
-
-          # 解码base64编码的keystore文件
-          printf '%s' "$KEY_BASE64" | base64 -d > app/app.key
-
-          # 写入签名配置到local.properties
-          printf '%s' "$SIGNING_CONFIG" > local.properties
-
-      - name: Gradle Build
-        run: |
-          chmod +x gradlew
-          ./gradlew assembleRelease
-
-      - name: Verify signed arm64 APK
-        run: |
-          apk="app/build/outputs/apk/release/app-arm64-v8a-release.apk"
+          set -euo pipefail
+          apk="app/build/outputs/apk/nightly/app-arm64-v8a-nightly.apk"
           if [ ! -f "$apk" ]; then
-            echo "Signed arm64 release APK is missing: $apk" >&2
+            echo "Nightly arm64 APK is missing: $apk" >&2
             exit 1
           fi
 
-          apksigner="$(find "$ANDROID_SDK_ROOT/build-tools" -type f -name apksigner | sort -V | tail -n 1)"
-          if [ -z "$apksigner" ]; then
-            echo "apksigner was not found in the Android SDK" >&2
+          android_sdk_dir="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+          if [ -z "$android_sdk_dir" ]; then
+            echo "Android SDK path is not configured" >&2
             exit 1
           fi
-          "$apksigner" verify --verbose "$apk"
+          aapt="$(find "$android_sdk_dir/build-tools" -type f -name aapt | sort -V | tail -n 1)"
+          apksigner="$(find "$android_sdk_dir/build-tools" -type f -name apksigner | sort -V | tail -n 1)"
+          if [ -z "$aapt" ] || [ -z "$apksigner" ]; then
+            echo "Android APK verification tools were not found" >&2
+            exit 1
+          fi
 
-      # 把 APK 直接发布为 Prerelease，用户点链接即可下载单个 apk，无需登录、无需解压
-      - name: Publish nightly prerelease
-        uses: softprops/action-gh-release@v2
-        if: success()
+          badging="$($aapt dump badging "$apk")"
+          package_name="$(printf '%s\n' "$badging" | sed -n "s/^package: name='\([^']*\)'.*/\1/p")"
+          version_name="$(printf '%s\n' "$badging" | sed -n "s/^package:.* versionName='\([^']*\)'.*/\1/p")"
+          if [ "$package_name" != "me.ayuilos.miffan.app.nightly" ]; then
+            echo "Unexpected nightly package name: $package_name" >&2
+            exit 1
+          fi
+          case "$version_name" in
+            *-nightly) ;;
+            *)
+              echo "Nightly version is not clearly marked: $version_name" >&2
+              exit 1
+              ;;
+          esac
+
+          signer_digest="$($apksigner verify --print-certs "$apk" | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' | head -n 1 | tr '[:lower:]' '[:upper:]')"
+          signer_digest="${signer_digest//:/}"
+          if [ -z "$signer_digest" ]; then
+            echo "Unable to read the nightly signing certificate" >&2
+            exit 1
+          fi
+          if [ "$signer_digest" = "$PRODUCTION_CERT_SHA256" ]; then
+            echo "Nightly APK must never use the Miffan production certificate" >&2
+            exit 1
+          fi
+
+          short_sha="${GITHUB_SHA:0:12}"
+          staged="app/build/nightly-staging/Miffan-nightly-$short_sha-arm64-v8a.apk"
+          mkdir -p "$(dirname "$staged")"
+          cp "$apk" "$staged"
+          echo "apk_path=$staged" >> "$GITHUB_OUTPUT"
+
+      - name: Upload non-production nightly artifact
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: nightly            # 固定 tag，每晚覆盖同一个「最新每日构建」
-          name: Miffan Nightly Build
-          prerelease: true
-          body: |
-            Miffan 自动每日构建（commit `${{ github.sha }}`）
+          name: Miffan-nightly-${{ github.sha }}
+          path: ${{ steps.stage.outputs.apk_path }}
+          if-no-files-found: error
+          retention-days: 14
 
-            > ⚠️ 开发版本，可能不稳定，仅供测试。
-            >
-            > Miffan 的应用 ID 为 `me.ayuilos.miffan.app`，可与上游 RikkaHub 同时安装。两者的数据、设置和权限相互独立。
-          files: app/build/outputs/apk/release/app-arm64-v8a-release.apk
+      - name: Summarize nightly channel
+        run: |
+          echo '### Non-production nightly' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Package: `me.ayuilos.miffan.app.nightly`' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Signing: ephemeral CI debug certificate (never the production certificate)' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Upgrade policy: disposable test artifact; the signer may change between runs, so in-place upgrades are not guaranteed' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Distribution: workflow artifact only; no tag or GitHub Release is created' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,269 @@
+name: Prepare Production Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Full 40-character commit SHA to build
+        required: true
+        type: string
+      release_version:
+        description: Exact SemVer in app/build.gradle.kts (for example, 3.0.0-rc.1)
+        required: true
+        type: string
+      version_code:
+        description: Exact Android versionCode in app/build.gradle.kts
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: production-release-${{ inputs.release_version }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: production
+    env:
+      EXPECTED_COMMIT: ${{ inputs.commit_sha }}
+      EXPECTED_VERSION: ${{ inputs.release_version }}
+      EXPECTED_VERSION_CODE: ${{ inputs.version_code }}
+      EXPECTED_PACKAGE: me.ayuilos.miffan.app
+      PRODUCTION_CERT_SHA256: 6C4B841AD2EF148C888D38411F0268C6C6FA908B5E0D009EA187BFAF2F1F9D31
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: recursive
+
+      - name: Validate explicit release inputs
+        id: release_inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$EXPECTED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "commit_sha must be a full 40-character SHA" >&2
+            exit 1
+          fi
+          if [ "$(git rev-parse HEAD)" != "${EXPECTED_COMMIT,,}" ]; then
+            echo "Checkout does not match the requested commit" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin master:refs/remotes/origin/master
+          if ! git merge-base --is-ancestor "$EXPECTED_COMMIT" origin/master; then
+            echo "Requested commit must be reachable from origin/master" >&2
+            exit 1
+          fi
+
+          semver_regex='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$EXPECTED_VERSION" =~ $semver_regex ]]; then
+            echo "release_version must be an independent SemVer without a v prefix" >&2
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_VERSION_CODE" =~ ^[1-9][0-9]*$ ]]; then
+            echo "version_code must be a positive integer" >&2
+            exit 1
+          fi
+          version_without_build="${EXPECTED_VERSION%%+*}"
+          is_prerelease=false
+          if [[ "$version_without_build" == *-* ]]; then
+            is_prerelease=true
+            prerelease="${version_without_build#*-}"
+            IFS='.' read -ra prerelease_identifiers <<< "$prerelease"
+            for identifier in "${prerelease_identifiers[@]}"; do
+              if [[ "$identifier" =~ ^[0-9]+$ && "$identifier" == 0* && "$identifier" != "0" ]]; then
+                echo "Numeric SemVer prerelease identifiers must not contain leading zeroes" >&2
+                exit 1
+              fi
+            done
+          fi
+          echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
+
+          source_version="$(sed -n 's/^[[:space:]]*versionName = "\([^"]*\)"/\1/p' app/build.gradle.kts | head -n 1)"
+          source_version_code="$(sed -n 's/^[[:space:]]*versionCode = \([0-9][0-9]*\)/\1/p' app/build.gradle.kts | head -n 1)"
+          if [ "$source_version" != "$EXPECTED_VERSION" ]; then
+            echo "Source versionName $source_version does not match $EXPECTED_VERSION" >&2
+            exit 1
+          fi
+          if [ "$source_version_code" != "$EXPECTED_VERSION_CODE" ]; then
+            echo "Source versionCode $source_version_code does not match $EXPECTED_VERSION_CODE" >&2
+            exit 1
+          fi
+          if [ ! -f "docs/releases/$EXPECTED_VERSION.md" ]; then
+            echo "Missing bilingual release notes: docs/releases/$EXPECTED_VERSION.md" >&2
+            exit 1
+          fi
+
+          set +e
+          git ls-remote --exit-code --tags origin "refs/tags/$EXPECTED_VERSION" >/dev/null 2>&1
+          tag_status=$?
+          set -e
+          case "$tag_status" in
+            0)
+              echo "Tag $EXPECTED_VERSION already exists; refusing to move or replace it" >&2
+              exit 1
+              ;;
+            2) ;;
+            *)
+              echo "Unable to verify that tag $EXPECTED_VERSION is unused" >&2
+              exit 1
+              ;;
+          esac
+
+          release_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$EXPECTED_VERSION")"
+          case "$release_status" in
+            404) ;;
+            200)
+              echo "Release $EXPECTED_VERSION already exists; refusing to replace it" >&2
+              exit 1
+              ;;
+            *)
+              echo "Unable to verify that Release $EXPECTED_VERSION is unused (HTTP $release_status)" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web-ui/pnpm-lock.yaml
+
+      - name: Install web-ui dependencies
+        working-directory: web-ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Prepare production signing credentials
+        shell: bash
+        env:
+          KEY_BASE64: ${{ secrets.KEY_BASE64 }}
+          SIGNING_CONFIG: ${{ secrets.SIGNING_CONFIG }}
+        run: |
+          set -euo pipefail
+          if [ -z "$KEY_BASE64" ] || [ -z "$SIGNING_CONFIG" ]; then
+            echo "Production signing secrets are missing from the production Environment" >&2
+            exit 1
+          fi
+          umask 077
+          printf '%s' "$KEY_BASE64" | base64 --decode > app/app.key
+          printf '%s' "$SIGNING_CONFIG" > local.properties
+
+      - name: Build production release from requested commit
+        run: ./gradlew test lint assembleRelease --stacktrace
+
+      - name: Verify package, version, ABI, and production signature
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          apk="app/build/outputs/apk/release/app-arm64-v8a-release.apk"
+          if [ ! -f "$apk" ]; then
+            echo "Signed arm64 release APK is missing: $apk" >&2
+            exit 1
+          fi
+
+          android_sdk_dir="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+          if [ -z "$android_sdk_dir" ]; then
+            echo "Android SDK path is not configured" >&2
+            exit 1
+          fi
+          aapt="$(find "$android_sdk_dir/build-tools" -type f -name aapt | sort -V | tail -n 1)"
+          apksigner="$(find "$android_sdk_dir/build-tools" -type f -name apksigner | sort -V | tail -n 1)"
+          if [ -z "$aapt" ] || [ -z "$apksigner" ]; then
+            echo "Android APK verification tools were not found" >&2
+            exit 1
+          fi
+
+          badging="$($aapt dump badging "$apk")"
+          package_name="$(printf '%s\n' "$badging" | sed -n "s/^package: name='\([^']*\)'.*/\1/p")"
+          version_name="$(printf '%s\n' "$badging" | sed -n "s/^package:.* versionName='\([^']*\)'.*/\1/p")"
+          version_code="$(printf '%s\n' "$badging" | sed -n "s/^package:.* versionCode='\([^']*\)'.*/\1/p")"
+          native_code="$(printf '%s\n' "$badging" | sed -n 's/^native-code: //p')"
+          if [ "$package_name" != "$EXPECTED_PACKAGE" ]; then
+            echo "Unexpected production package name: $package_name" >&2
+            exit 1
+          fi
+          if [ "$version_name" != "$EXPECTED_VERSION" ] || [ "$version_code" != "$EXPECTED_VERSION_CODE" ]; then
+            echo "APK version $version_name/$version_code does not match requested version" >&2
+            exit 1
+          fi
+          if [ "$native_code" != "'arm64-v8a'" ]; then
+            echo "Release APK is not arm64-only: $native_code" >&2
+            exit 1
+          fi
+
+          signer_digest="$($apksigner verify --print-certs "$apk" | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' | head -n 1 | tr '[:lower:]' '[:upper:]')"
+          signer_digest="${signer_digest//:/}"
+          if [ "$signer_digest" != "$PRODUCTION_CERT_SHA256" ]; then
+            echo "APK signature does not match the Miffan production trust anchor" >&2
+            exit 1
+          fi
+
+          asset_name="Miffan-$EXPECTED_VERSION-arm64-v8a.apk"
+          staging_dir="app/build/release-staging"
+          mkdir -p "$staging_dir"
+          cp "$apk" "$staging_dir/$asset_name"
+          (
+            cd "$staging_dir"
+            sha256sum "$asset_name" > "$asset_name.sha256"
+          )
+          echo "apk_path=$staging_dir/$asset_name" >> "$GITHUB_OUTPUT"
+          echo "sha_path=$staging_dir/$asset_name.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Attest production APK build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ steps.stage.outputs.apk_path }}
+
+      - name: Upload verified release candidate artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Miffan-${{ inputs.release_version }}-verified
+          path: |
+            ${{ steps.stage.outputs.apk_path }}
+            ${{ steps.stage.outputs.sha_path }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Prepare draft GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.release_version }}
+          name: ${{ inputs.release_version }}
+          target_commitish: ${{ inputs.commit_sha }}
+          body_path: docs/releases/${{ inputs.release_version }}.md
+          draft: true
+          prerelease: ${{ steps.release_inputs.outputs.is_prerelease }}
+          make_latest: false
+          fail_on_unmatched_files: true
+          files: |
+            ${{ steps.stage.outputs.apk_path }}
+            ${{ steps.stage.outputs.sha_path }}

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Miffan currently distributes signed APKs through [GitHub Releases](https://githu
 
 Miffan uses the application ID `me.ayuilos.miffan.app` and the `miffan://` deep-link scheme. Existing RikkaHub data is not shared automatically; export a backup from the old app and import it into Miffan if you want to migrate.
 
+Beginning with `3.0.0-rc.1`, Miffan uses an independent SemVer release line that does not encode a RikkaHub version. Official APKs retain the existing package and production signing identity, so `2.4.11-miffan.1` can be upgraded in place without changing the app's data or database compatibility policy. Nightly workflow artifacts use `me.ayuilos.miffan.app.nightly` and an ephemeral CI debug signer; they install separately and cannot replace an official build. Nightlies are disposable test artifacts, and the signer may change between runs, so in-place upgrades between Nightlies are not guaranteed.
+
 ## Security and privacy notes
 
 Miffan is a client: prompts, attachments, and tool data are sent to the model, search, speech, MCP, sync, or other endpoints you choose. Review the privacy policy and pricing of every service you configure. The repository's data-flow disclosures are in [PRIVACY.md](PRIVACY.md).
@@ -157,7 +159,7 @@ Useful verification commands:
 
 ## Project history and attribution
 
-Miffan began as a community fork of [RikkaHub](https://github.com/rikkahub/rikkahub) and continues to incorporate selected upstream improvements. It is now maintained as an independent application with its own product identity, character system, package name, signing certificate, release line, and feature development.
+Miffan began as a community fork of [RikkaHub](https://github.com/rikkahub/rikkahub) and continues to incorporate selected upstream improvements. It is now maintained as an independent application with its own product identity, character system, package name, signing certificate, release line, and feature development. RikkaHub is treated as a selective code input rather than a product-version source; the review and provenance rules are documented in the [upstream synchronization policy](docs/upstream-sync.md).
 
 Upstream copyright and attribution are retained as required by the license. Miffan is not an official RikkaHub release.
 

--- a/README_ZH_CN.md
+++ b/README_ZH_CN.md
@@ -115,6 +115,8 @@ Miffan 目前通过 [GitHub Releases](https://github.com/Ayuilos/Miffan/releases
 
 Miffan 的应用 ID 为 `me.ayuilos.miffan.app`，深链协议为 `miffan://`。RikkaHub 的已有数据不会自动共享；如需迁移，请先在旧 APP 中导出备份，再导入 Miffan。
 
+从 `3.0.0-rc.1` 起，Miffan 使用不再编码 RikkaHub 版本的独立 SemVer 发布线。正式 APK 保留既有包名和生产签名身份，因此 `2.4.11-miffan.1` 可在不改变用户数据或数据库兼容策略的前提下原地升级。Nightly 工作流产物使用 `me.ayuilos.miffan.app.nightly` 和 CI 临时 debug 签名，只能独立安装，不能覆盖正式版。Nightly 属于一次性测试产物；不同运行的签名可能变化，因此不保证 Nightly 之间可以原地升级。
+
 ## 安全与隐私说明
 
 Miffan 是客户端：提示词、附件和工具数据会发送到你选择的模型、搜索、语音、MCP、同步或其他服务端点。请分别了解所配置服务的隐私政策和计费方式。详细数据流说明见 [PRIVACY.md](PRIVACY.md)。
@@ -157,7 +159,7 @@ cd Miffan
 
 ## 项目历史与归属
 
-Miffan 最初源自 [RikkaHub](https://github.com/rikkahub/rikkahub) 的社区分支，并会继续选择性吸收上游改进。现在它作为独立应用维护，拥有自己的产品定位、角色系统、包名、签名证书、发布版本线与功能开发方向。
+Miffan 最初源自 [RikkaHub](https://github.com/rikkahub/rikkahub) 的社区分支，并会继续选择性吸收上游改进。现在它作为独立应用维护，拥有自己的产品定位、角色系统、包名、签名证书、发布版本线与功能开发方向。RikkaHub 仅作为选择性代码输入，而不是产品版本来源；具体审查与来源记录规则见[上游同步策略](docs/upstream-sync.md)。
 
 项目会依照许可证保留上游版权与归属信息。Miffan 不是 RikkaHub 的官方版本。
 

--- a/README_ZH_TW.md
+++ b/README_ZH_TW.md
@@ -115,6 +115,8 @@ Miffan 目前透過 [GitHub Releases](https://github.com/Ayuilos/Miffan/releases
 
 Miffan 的應用程式 ID 為 `me.ayuilos.miffan.app`，Deep Link 協定為 `miffan://`。RikkaHub 的既有資料不會自動共享；如需移轉，請先在舊 APP 中匯出備份，再匯入 Miffan。
 
+自 `3.0.0-rc.1` 起，Miffan 採用不再編入 RikkaHub 版本的獨立 SemVer 發布線。正式 APK 保留既有套件名稱與正式簽署身分，因此 `2.4.11-miffan.1` 可在不變更使用者資料或資料庫相容策略的前提下原地升級。Nightly 工作流程成品使用 `me.ayuilos.miffan.app.nightly` 與 CI 臨時 debug 簽署，只能分開安裝，不能覆蓋正式版。Nightly 屬於一次性測試產物；不同執行的簽署可能變更，因此不保證 Nightly 之間可以原地升級。
+
 ## 安全與隱私說明
 
 Miffan 是用戶端：提示詞、附件和工具資料會傳送到你選擇的模型、搜尋、語音、MCP、同步或其他服務端點。請分別了解所設定服務的隱私權政策和計費方式。詳細資料流說明見 [PRIVACY.md](PRIVACY.md)。
@@ -157,7 +159,7 @@ cd Miffan
 
 ## 專案歷史與歸屬
 
-Miffan 最初源自 [RikkaHub](https://github.com/rikkahub/rikkahub) 的社群分支，並會繼續選擇性吸收上游改進。現在它作為獨立應用程式維護，擁有自己的產品定位、角色系統、套件名稱、簽署憑證、發布版本線與功能開發方向。
+Miffan 最初源自 [RikkaHub](https://github.com/rikkahub/rikkahub) 的社群分支，並會繼續選擇性吸收上游改進。現在它作為獨立應用程式維護，擁有自己的產品定位、角色系統、套件名稱、簽署憑證、發布版本線與功能開發方向。RikkaHub 僅作為選擇性的程式碼輸入，而不是產品版本來源；具體審查與來源記錄規則請見[上游同步策略](docs/upstream-sync.md)。
 
 專案會依照授權條款保留上游版權與歸屬資訊。Miffan 不是 RikkaHub 的官方版本。
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "me.ayuilos.miffan.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 178001
-        versionName = "2.4.11-miffan.1"
+        versionCode = 178002
+        versionName = "3.0.0-rc.1"
 
         buildConfigField("boolean", "FIREBASE_ENABLED", hasGoogleServicesConfig.toString())
 
@@ -94,6 +94,18 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             buildConfigField("String", "VERSION_NAME", "\"${android.defaultConfig.versionName}\"")
+            buildConfigField("String", "VERSION_CODE", "\"${android.defaultConfig.versionCode}\"")
+        }
+        create("nightly") {
+            initWith(getByName("debug"))
+            applicationIdSuffix = ".nightly"
+            versionNameSuffix = "-nightly"
+            matchingFallbacks += listOf("debug")
+            buildConfigField(
+                "String",
+                "VERSION_NAME",
+                "\"${android.defaultConfig.versionName}-nightly\"",
+            )
             buildConfigField("String", "VERSION_CODE", "\"${android.defaultConfig.versionCode}\"")
         }
     }
@@ -312,6 +324,7 @@ dependencies {
 
     // tests
     testImplementation(libs.junit)
+    testImplementation("net.sf.kxml:kxml2:2.3.0")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/me/ayuilos/miffan/utils/UpdateChecker.kt
+++ b/app/src/main/java/me/ayuilos/miffan/utils/UpdateChecker.kt
@@ -34,7 +34,21 @@ private const val GITHUB_RELEASE_ATOM_URL =
     "https://github.com/Ayuilos/Miffan/releases.atom"
 private const val GITHUB_RELEASES_URL =
     "https://github.com/Ayuilos/Miffan/releases"
-private val MIFFAN_RELEASE_VERSION = Regex("""\d+\.\d+\.\d+-miffan\.\d+""")
+private const val SEMVER_NUMERIC_IDENTIFIER = "(?:0|[1-9]\\d*)"
+private const val SEMVER_NON_NUMERIC_IDENTIFIER = "(?:\\d*[A-Za-z-][0-9A-Za-z-]*)"
+private const val SEMVER_PRERELEASE_IDENTIFIER =
+    "(?:$SEMVER_NUMERIC_IDENTIFIER|$SEMVER_NON_NUMERIC_IDENTIFIER)"
+private const val SEMVER_BUILD_IDENTIFIER = "[0-9A-Za-z-]+"
+private val LEGACY_MIFFAN_RELEASE_VERSION = Regex(
+    "$SEMVER_NUMERIC_IDENTIFIER\\.$SEMVER_NUMERIC_IDENTIFIER\\." +
+        "$SEMVER_NUMERIC_IDENTIFIER-miffan\\.$SEMVER_NUMERIC_IDENTIFIER"
+)
+private val STANDARD_SEMVER = Regex(
+    "($SEMVER_NUMERIC_IDENTIFIER)\\.($SEMVER_NUMERIC_IDENTIFIER)\\." +
+        "($SEMVER_NUMERIC_IDENTIFIER)" +
+        "(?:-($SEMVER_PRERELEASE_IDENTIFIER(?:\\.$SEMVER_PRERELEASE_IDENTIFIER)*))?" +
+        "(?:\\+($SEMVER_BUILD_IDENTIFIER(?:\\.$SEMVER_BUILD_IDENTIFIER)*))?"
+)
 
 class UpdateChecker(
     client: OkHttpClient,
@@ -184,6 +198,9 @@ internal data class GitHubReleaseAsset(
 
 internal fun GitHubRelease.toUpdateInfo(): UpdateInfo {
     require(!draft && !prerelease) { "The latest GitHub release is not a formal release" }
+    require(tagName.isFormalMiffanReleaseVersion()) {
+        "The latest GitHub release tag is not a formal Miffan version: $tagName"
+    }
     val version = tagName.toMiffanReleaseVersion()
     val expectedAssetName = apkAssetName(version)
     val downloads = assets
@@ -208,10 +225,11 @@ internal fun GitHubRelease.toUpdateInfo(): UpdateInfo {
     )
 }
 
-internal fun parseLatestMiffanReleaseAtom(xml: String): UpdateInfo {
-    val parser = Xml.newPullParser().apply {
-        setInput(StringReader(xml))
-    }
+internal fun parseLatestMiffanReleaseAtom(
+    xml: String,
+    parser: XmlPullParser = Xml.newPullParser(),
+): UpdateInfo {
+    parser.setInput(StringReader(xml))
     var inEntry = false
     var currentTextTag: String? = null
     val text = StringBuilder()
@@ -255,9 +273,12 @@ internal fun parseLatestMiffanReleaseAtom(xml: String): UpdateInfo {
 
                     parser.name == "entry" -> {
                         val tag = releaseLink
-                            ?.substringAfter("$GITHUB_RELEASES_URL/tag/", missingDelimiterValue = "")
+                            ?.substringAfter(
+                                "$GITHUB_RELEASES_URL/tag/",
+                                missingDelimiterValue = "",
+                            )
                             ?.substringBefore('?')
-                            ?.takeIf { MIFFAN_RELEASE_VERSION.matches(it) }
+                            ?.takeIf { it.isFormalMiffanReleaseVersion() }
                         if (tag != null) {
                             return UpdateInfo(
                                 version = tag,
@@ -287,10 +308,19 @@ internal fun parseLatestMiffanReleaseAtom(xml: String): UpdateInfo {
 }
 
 private fun String.toMiffanReleaseVersion(): String {
-    require(MIFFAN_RELEASE_VERSION.matches(this)) {
+    require(isSupportedMiffanReleaseVersion()) {
         "Unexpected Miffan release tag: $this"
     }
     return this
+}
+
+internal fun String.isSupportedMiffanReleaseVersion(): Boolean =
+    LEGACY_MIFFAN_RELEASE_VERSION.matches(this) || STANDARD_SEMVER.matches(this)
+
+private fun String.isFormalMiffanReleaseVersion(): Boolean {
+    if (LEGACY_MIFFAN_RELEASE_VERSION.matches(this)) return true
+    val match = STANDARD_SEMVER.matchEntire(this) ?: return false
+    return match.groupValues[4].isEmpty()
 }
 
 private fun apkAssetName(version: String): String =

--- a/app/src/test/java/me/ayuilos/miffan/utils/GitHubReleaseMappingTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/utils/GitHubReleaseMappingTest.kt
@@ -1,7 +1,9 @@
 package me.ayuilos.miffan.utils
 
 import kotlinx.serialization.json.Json
+import org.kxml2.io.KXmlParser
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -46,10 +48,45 @@ class GitHubReleaseMappingTest {
     }
 
     @Test
-    fun `non-Miffan release tag is rejected`() {
+    fun `independent SemVer release maps new APK name`() {
+        val release = GitHubRelease(
+            tagName = "3.0.0",
+            publishedAt = "2026-09-01T00:00:00Z",
+            assets = listOf(
+                GitHubReleaseAsset(
+                    name = "Miffan-3.0.0-arm64-v8a.apk",
+                    browserDownloadUrl =
+                        "https://github.com/Ayuilos/Miffan/releases/download/3.0.0/" +
+                            "Miffan-3.0.0-arm64-v8a.apk",
+                    size = 41_000_000,
+                )
+            ),
+        )
+
+        val info = release.toUpdateInfo()
+
+        assertEquals("3.0.0", info.version)
+        assertEquals("Miffan-3.0.0-arm64-v8a.apk", info.downloads.single().name)
+        assertEquals(
+            "https://github.com/Ayuilos/Miffan/releases/tag/3.0.0",
+            info.releaseUrl,
+        )
+    }
+
+    @Test
+    fun `legacy and independent SemVer tags are supported`() {
+        assertTrue("2.4.11-miffan.1".isSupportedMiffanReleaseVersion())
+        assertTrue("3.0.0".isSupportedMiffanReleaseVersion())
+        assertTrue("3.0.0-rc.1".isSupportedMiffanReleaseVersion())
+        assertFalse("03.0.0".isSupportedMiffanReleaseVersion())
+        assertFalse("3.0.0-rc.01".isSupportedMiffanReleaseVersion())
+    }
+
+    @Test
+    fun `unsupported release tag is rejected`() {
         val result = runCatching {
             GitHubRelease(
-                tagName = "2.4.10",
+                tagName = "release-3.0.0",
                 publishedAt = "2026-08-24T00:00:00Z",
             ).toUpdateInfo()
         }
@@ -68,7 +105,7 @@ class GitHubReleaseMappingTest {
         }
         val prereleaseResult = runCatching {
             GitHubRelease(
-                tagName = "2.4.10-miffan.6",
+                tagName = "3.0.0",
                 publishedAt = "2026-08-24T00:00:00Z",
                 prerelease = true,
             ).toUpdateInfo()
@@ -78,7 +115,69 @@ class GitHubReleaseMappingTest {
         assertTrue(prereleaseResult.isFailure)
     }
 
+    @Test
+    fun `SemVer prerelease tag is rejected even when release metadata is misclassified`() {
+        val result = runCatching {
+            GitHubRelease(
+                tagName = "3.0.0-rc.1",
+                publishedAt = "2026-08-24T00:00:00Z",
+                prerelease = false,
+            ).toUpdateInfo()
+        }
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `Atom fallback skips SemVer prereleases and maps next formal release`() {
+        val info = parseAtom(
+            """
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry>
+                <updated>2026-08-25T00:00:00Z</updated>
+                <link rel="alternate" href="https://github.com/Ayuilos/Miffan/releases/tag/3.0.0-rc.1" />
+                <content>Release candidate</content>
+              </entry>
+              <entry>
+                <updated>2026-09-01T00:00:00Z</updated>
+                <link rel="alternate" href="https://github.com/Ayuilos/Miffan/releases/tag/3.0.0" />
+                <content>Formal release</content>
+              </entry>
+            </feed>
+            """.trimIndent()
+        )
+
+        assertEquals("3.0.0", info.version)
+        assertEquals("Miffan-3.0.0-arm64-v8a.apk", info.downloads.single().name)
+        assertEquals(
+            "https://github.com/Ayuilos/Miffan/releases/download/3.0.0/" +
+                "Miffan-3.0.0-arm64-v8a.apk",
+            info.downloads.single().url,
+        )
+    }
+
+    @Test
+    fun `Atom fallback retains historical formal release compatibility`() {
+        val info = parseAtom(
+            """
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry>
+                <updated>2026-08-23T15:29:40Z</updated>
+                <link rel="alternate" href="https://github.com/Ayuilos/Miffan/releases/tag/2.4.11-miffan.1" />
+                <content>Historical release</content>
+              </entry>
+            </feed>
+            """.trimIndent()
+        )
+
+        assertEquals("2.4.11-miffan.1", info.version)
+        assertEquals("Miffan-2.4.11-miffan.1-arm64-v8a.apk", info.downloads.single().name)
+    }
+
     private companion object {
         val json = Json { ignoreUnknownKeys = true }
+
+        fun parseAtom(xml: String): UpdateInfo =
+            parseLatestMiffanReleaseAtom(xml, KXmlParser())
     }
 }

--- a/app/src/test/java/me/ayuilos/miffan/utils/VersionTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/utils/VersionTest.kt
@@ -36,6 +36,12 @@ class VersionTest {
     }
 
     @Test
+    fun `legacy Miffan releases upgrade into independent version line`() {
+        assertTrue(Version("2.4.11-miffan.1") < Version("3.0.0-rc.1"))
+        assertTrue(Version("3.0.0-rc.1") < Version("3.0.0"))
+    }
+
+    @Test
     fun `prerelease with more fields has higher precedence`() {
         assertTrue(Version("1.0.0-alpha") < Version("1.0.0-alpha.1"))
     }

--- a/docs/releases/3.0.0-rc.1.md
+++ b/docs/releases/3.0.0-rc.1.md
@@ -1,0 +1,35 @@
+# Miffan 3.0.0-rc.1
+
+> 这是 Miffan 独立 3.x 发布线的首个候选版本。正式包名与生产签名保持不变，可从 `2.4.11-miffan.1` 原地升级；作为 RC，建议先备份并在测试设备上验证。此版本不会通过正式更新源自动推送。
+
+更新内容：
+
+### Miffan 自有改动
+
+- 启用独立的 Miffan 3.x SemVer 版本线，并让过渡版本同时识别历史 `x.y.z-miffan.n` 与新的 SemVer，为后续 `3.0.0` 正式版升级做好准备。
+- 将 Nightly 与正式安装隔离；Nightly 使用独立包名和 CI 临时非生产签名，是一次性测试产物，不会覆盖正式版或共享其数据，也不保证不同构建间可原地升级。
+- 优化软键盘弹出时的聊天输入区布局，在保持动画稳定的同时继续显示常用输入工具。
+
+### 同步自 RikkaHub
+
+- 修复分支会话未继承文件夹和工作区目录的问题。
+- 提升 Skills 元数据解析的稳定性与兼容性。
+- 改进 OpenRouter 会话连续性，并兼容空的 Chat Completions 工具参数结构。
+- 补全供应商连接测试界面的本地化文本。
+- 更新工作区运行组件，改善终端环境兼容性。
+
+Updates:
+
+### Miffan changes
+
+- Introduced Miffan's independent 3.x SemVer line and made the transition build understand both historical `x.y.z-miffan.n` tags and new SemVer tags, preparing the path to the stable `3.0.0` update.
+- Isolated Nightly from official installations with a separate package name and ephemeral CI non-production signer. It is a disposable test artifact that cannot replace or share data with the official app, and in-place upgrades between runs are not guaranteed.
+- Refined the chat input layout when the keyboard opens, preserving commonly used input tools while keeping the animation stable.
+
+### Synced from RikkaHub
+
+- Fixed branched conversations not inheriting their folder and workspace directory.
+- Improved the stability and compatibility of Skills metadata parsing.
+- Improved OpenRouter session continuity and compatibility with empty Chat Completions tool parameter schemas.
+- Completed localization for the provider connection test interface.
+- Updated workspace runtime components for better terminal environment compatibility.

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -1,0 +1,23 @@
+# <version>
+
+> Optional release-channel or upgrade notice. Keep it concise and user-facing.
+
+更新内容：
+
+### Miffan 自有改动
+
+- 本次无面向用户的改动。
+
+### 同步自 RikkaHub
+
+- 本次无面向用户的改动。
+
+Updates:
+
+### Miffan changes
+
+- No user-facing changes in this release.
+
+### Synced from RikkaHub
+
+- No user-facing changes in this release.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,38 +1,77 @@
-# Miffan APK release process
+# Miffan release process
 
-Formal Miffan releases use the version in `app/build.gradle.kts` and a tag with the exact version number, without a `v` prefix. This project distributes APKs directly and does not publish an AAB to Google Play.
+Miffan is an independent project with its own version line, package identity, signing trust anchor, and GitHub Releases. RikkaHub remains an optional source of selected code improvements, not a source of Miffan product versions. See [upstream-sync.md](upstream-sync.md) for the upstream policy.
 
-## Application identity
+## Application identity and channels
 
-Miffan is installed as an application independent from upstream RikkaHub:
+Official Miffan releases keep all of these values stable:
 
 - namespace: `me.ayuilos.miffan`
 - application ID: `me.ayuilos.miffan.app`
 - deep-link scheme: `miffan://`
+- production signing certificate: the trust anchor recorded below
 
-The separate application ID lets Miffan and upstream RikkaHub coexist on the same Android device even though they use different signing certificates. Their private data, permissions, databases, and settings are separate. Users who want to migrate existing data must export it from the old app and import it into Miffan.
+The release channels are intentionally isolated:
 
-## Version scheme
+| Channel | Gradle build type | Application ID | Signing | Distribution |
+| --- | --- | --- | --- | --- |
+| Official / release candidate | `release` | `me.ayuilos.miffan.app` | Miffan production certificate | Verified draft GitHub Release, then explicit publication approval |
+| Nightly | `nightly` | `me.ayuilos.miffan.app.nightly` | Ephemeral CI debug certificate | Disposable GitHub Actions artifact only |
+| Local debug | `debug` | `me.ayuilos.miffan.app.debug` | Android debug certificate | Local or CI artifact |
 
-Keep the Miffan version distinct from upstream:
+Nightly never reads production signing secrets, never updates the fixed `nightly` tag, and never creates a GitHub Release. Its different application ID prevents a nightly APK from replacing or upgrading an official installation. Each hosted CI run uses a temporary debug signer that may differ from another run, so Nightly is a disposable test artifact and is not guaranteed to upgrade in place over an earlier Nightly. A fresh install may be required.
 
-- `versionName`: `<upstream-version>-miffan.<fork-revision>`
-- `versionCode`: `<upstream-version-code> * 1000 + <fork-revision>`
+## Independent version scheme
 
-For example, the first Miffan release based on upstream `2.4.10` (`versionCode` 177) is `2.4.10-miffan.1` with `versionCode` 177001. Increment only the fork revision for releases on the same upstream base. After rebasing to a newer upstream release, use that release's version and code as the new base.
+New Miffan releases use standard Semantic Versioning without a `v` prefix:
 
-Miffan checks the latest formal release published in `Ayuilos/Miffan` on GitHub. Keep the release tag identical to `versionName` and attach the arm64 APK using the name `Miffan-<version>-arm64-v8a.apk`; the in-app updater uses those GitHub Releases as its source of truth.
+- stable: `MAJOR.MINOR.PATCH`, for example `3.0.0`
+- prerelease: `MAJOR.MINOR.PATCH-PRERELEASE`, for example `3.0.0-rc.1`
+- tag and Release title: exactly the same as `versionName`
 
-## Prepare
+Do not encode an upstream RikkaHub version or sync revision in a new Miffan version. Historical versions such as `2.4.11-miffan.1` remain supported only as updater and upgrade-acceptance inputs.
 
-1. Start from an up-to-date, clean `master` worktree and inspect the commits since the upstream base tag and the latest Miffan release tag.
-2. Increment both `versionName` and `versionCode` according to the scheme above.
-3. Add bilingual release notes to `docs/releases/<version>.md`. Keep the user-facing change list to no more than ten items and avoid implementation details.
-4. Confirm the release notes with the user before creating a GitHub Release.
+`versionCode` is an Android upgrade counter, independent of SemVer. Every installable release APK that uses `me.ayuilos.miffan.app` and the production certificate must have a `versionCode` strictly greater than every previously distributed upgrade-capable APK. It does not need to encode the SemVer components.
 
-## Configure signing
+The first candidate in the independent line is:
 
-Release signing credentials are local or CI secrets and must never be committed. For a local build, place the authorized keystore outside version control and configure these entries in the ignored root `local.properties` file:
+- `versionName`: `3.0.0-rc.1`
+- `versionCode`: `178002`
+
+Because the RC uses the official package name, the eventual `3.0.0` release must use a value greater than `178002`.
+
+## Update compatibility and safety boundary
+
+The in-app updater accepts both generations of version tags:
+
+- historical formal tags: `x.y.z-miffan.n`
+- independent SemVer tags: `x.y.z` and syntactically valid prerelease tags such as `x.y.z-rc.n`
+
+The official update source still ignores drafts and prereleases. GitHub's latest-release API excludes them, and Miffan also rejects release metadata marked `draft` or `prerelease`. If the API is unavailable, the Atom fallback skips standard SemVer prereleases and selects the next historical formal tag or stable SemVer tag.
+
+Consequences for the transition:
+
+- `2.4.11-miffan.1` can be upgraded in place to the production-signed `3.0.0-rc.1` APK by an explicit RC installation.
+- The RC understands both version generations, so it will recognize a future stable `3.0.0` release.
+- The official updater does not automatically offer the RC; prerelease participation is opt-in.
+
+Official arm64 assets use `Miffan-<version>-arm64-v8a.apk`. The checksum companion uses the same name plus `.sha256`.
+
+## Production signing trust anchor
+
+The first Miffan production certificate was created on 2026-08-19. It must remain unchanged for every official update:
+
+- Subject: `CN=Miffan Release, OU=Android, O=Ayuilos, C=CN`
+- SHA-256: `6C:4B:84:1A:D2:EF:14:8C:88:8D:38:41:1F:02:68:C6:C6:FA:90:8B:5E:0D:00:9E:A1:87:BF:AF:2F:1F:9D:31`
+- Validity: 2026-08-19 through 2126-07-26
+
+The authorized local keystore remains outside the repository at `~/Library/Application Support/Miffan/signing/miffan-release.jks`. Its password is stored in the macOS login Keychain under the service `Miffan Release Keystore Password`. Back up the keystore and credential separately.
+
+GitHub copies of the keystore and signing properties must be stored as `KEY_BASE64` and `SIGNING_CONFIG` secrets in the `production` Environment. Do not put production signing secrets in repository-level nightly configuration, change their values in source, or reuse the certificate for `.nightly` builds.
+
+After the Environment copies have been verified, delete repository-level secrets with the same `KEY_BASE64` and `SIGNING_CONFIG` names. Keeping those duplicates would let a future workflow read production signing material without passing through the `production` Environment approval gate.
+
+For an authorized local build, configure the ignored root `local.properties`:
 
 ```properties
 storeFile=<path-to-existing-keystore>
@@ -41,59 +80,86 @@ keyAlias=<key-alias>
 keyPassword=<key-password>
 ```
 
-The first Miffan release needs a dedicated signing key stored outside version control. Keep that key and its credentials backed up: every later Miffan APK must use the same certificate to upgrade an installed Miffan release without data loss.
+When these four entries are absent, `assembleRelease` may produce unsigned verification APKs. They are not production releases and must not be distributed.
 
-If a new key must be created, generate it interactively outside the repository and omit passwords from shell history:
+`app/google-services.json` is optional. Only a configuration registered for `me.ayuilos.miffan.app` may be used; an upstream or nightly application ID configuration must not be substituted.
+
+## Prepare a release
+
+1. Start from an up-to-date, clean `master` and create a dedicated release branch.
+2. Select and record the exact target commit. Do not silently build a moving branch head.
+3. Set an independent SemVer `versionName` and a strictly increasing `versionCode` in `app/build.gradle.kts`.
+4. Add bilingual notes at `docs/releases/<version>.md` using [the template](releases/TEMPLATE.md). Keep Miffan-owned changes separate from improvements incorporated from RikkaHub.
+5. Require the PR/push CI workflow to pass `test`, `lint`, and `assembleDebug` before merging the target commit.
+6. Review the in-place upgrade acceptance below for any release that shares the official package name.
+
+No upstream tag is a Miffan release trigger. Do not fetch-and-push, mirror, or automatically propagate upstream tags.
+
+## Build a verified draft Release
+
+Run `.github/workflows/release.yml` manually and provide all three explicit inputs:
+
+- the target commit's full 40-character SHA;
+- the exact SemVer `versionName`;
+- the exact Android `versionCode`.
+
+The workflow is gated by the `production` Environment. It verifies that the requested commit, source version, and notes agree; refuses to replace an existing tag; runs tests and lint; builds the release; and checks:
+
+- application ID is `me.ayuilos.miffan.app`;
+- `versionName` and `versionCode` match the approved inputs;
+- the staged APK is arm64-only;
+- the signer SHA-256 matches the Miffan production trust anchor;
+- the asset name follows the official convention.
+
+It then computes SHA-256, creates GitHub build provenance for the verified APK with `actions/attest@v4`, uploads the verified APK/checksum as a workflow artifact, and prepares a draft GitHub Release at the requested commit. A version containing a prerelease component is marked as a prerelease. The workflow does not make the draft public; publication remains a separate approval.
+
+Download the APK and verify its build provenance before publication:
 
 ```bash
-keytool -genkeypair -v \
-  -keystore /secure/backup/location/miffan-release.jks \
-  -alias miffan \
-  -keyalg RSA -keysize 4096 -validity 10000
+gh attestation verify <apk> -R Ayuilos/Miffan
 ```
 
-Record the certificate digest with `keytool -list -v`, back up the keystore and credentials separately, then configure the ignored `local.properties` entries above. Do not commit either file.
+Treat the signer verification, SHA-256 checksum, and build-provenance verification as separate required checks.
 
-The first Miffan production certificate was created on 2026-08-19. Its identity must remain the trust anchor for every later Miffan update:
-
-- Subject: `CN=Miffan Release, OU=Android, O=Ayuilos, C=CN`
-- SHA-256: `6C:4B:84:1A:D2:EF:14:8C:88:8D:38:41:1F:02:68:C6:C6:FA:90:8B:5E:0D:00:9E:A1:87:BF:AF:2F:1F:9D:31`
-- Validity: 2026-08-19 through 2126-07-26
-
-The authorized local keystore is stored at `~/Library/Application Support/Miffan/signing/miffan-release.jks`; its password is stored in the macOS login Keychain under the service `Miffan Release Keystore Password`. Back up the keystore and its credential separately in secure, recoverable locations. The GitHub Actions copies are configured as the `KEY_BASE64` and `SIGNING_CONFIG` repository secrets.
-
-`app/google-services.json` is optional. When an authorized configuration for `me.ayuilos.miffan.app` is present, analytics and crash reporting are enabled. When it is absent, those integrations are disabled. A configuration registered for the upstream application ID must not be reused.
-
-When the four signing entries are absent, `assembleRelease` produces unsigned APKs for build verification. Those artifacts are not installable production releases and must not be published.
-
-## Verify and build
+For local verification without publication:
 
 ```bash
 ./gradlew test
 ./gradlew lint
 ./gradlew assembleRelease
-```
 
-Before distributing an APK, verify all of the following:
-
-- the package name is `me.ayuilos.miffan.app`;
-- the version name and code match the planned release;
-- only the `arm64-v8a` APK is staged for the formal release;
-- native libraries are compatible with 16 KB page-size devices;
-- the APK signature matches the certificate selected for Miffan releases;
-- the APK installs alongside upstream RikkaHub;
-- the APK upgrades the previous Miffan release without removing app data.
-
-The CI workflow verifies the arm64 APK signature before uploading it. An unsigned build therefore remains a local verification artifact instead of being published accidentally.
-
-Record the staged APK's SHA-256 digest. Rename and copy the arm64 artifact to the ignored staging directory:
-
-```bash
 mkdir -p app/release
-cp app/build/outputs/apk/release/app-arm64-v8a-release.apk app/release/Miffan-<version>-arm64-v8a.apk
+cp app/build/outputs/apk/release/app-arm64-v8a-release.apk \
+  app/release/Miffan-<version>-arm64-v8a.apk
 shasum -a 256 app/release/Miffan-<version>-arm64-v8a.apk
 ```
 
-## Publish after approval
+Never upload the universal or x86_64 APK to an official Release.
 
-Publishing is a separate, explicitly authorized action. After the user approves the notes, create the release with the version as the title and tag (no `v` prefix), attach only the staged arm64 APK, and use `docs/releases/<version>.md` as the description. Do not upload the universal or x86_64 APK.
+## In-place upgrade acceptance from 2.4.11-miffan.1
+
+This release migration does not change the app's data ownership, database compatibility policy, or migration strategy. Validate upgrades with a disposable device or emulator that represents real user state:
+
+1. Install the official, production-signed `2.4.11-miffan.1` APK.
+2. Create representative local state: a conversation, assistant/provider settings without live credentials, and a workspace reference or backup marker.
+3. Record the package, version, certificate digest, and a non-sensitive inventory of that state.
+4. Install the candidate with `adb install -r Miffan-<version>-arm64-v8a.apk`. Do not uninstall the old app and do not clear app data.
+5. Confirm Android reports the same package `me.ayuilos.miffan.app`, the higher `versionCode`, and the expected `versionName`.
+6. Launch Miffan and confirm the existing conversations, settings, files, and database open normally. Exercise startup and any existing Room migrations; do not add a release-only data reset or migration bypass.
+7. Confirm the updater in `3.0.0-rc.1` can parse and rank future `3.0.0` above the installed RC.
+
+Also verify a fresh install, coexistence with RikkaHub, deep links, and Android 8.0 minimum support. Any certificate mismatch or data loss blocks publication.
+
+## Publish after explicit approval
+
+Review the draft's target commit, bilingual notes, signer, APK, and checksum. Only after explicit authorization should the draft be published. Use the version as the title and tag without a `v` prefix. Do not move, replace, delete, or reuse an existing release tag.
+
+## Repository settings requiring manual administration
+
+These GitHub settings are deliberately outside the source change and require a repository administrator:
+
+- add a `master` ruleset requiring pull requests and the `CI / verify` status check;
+- add a tag ruleset for independent Miffan SemVer tags and restrict tag creation/deletion;
+- enable Release immutability and decide how to handle the existing non-immutable Releases;
+- create or review the `production` Environment, copy or migrate `KEY_BASE64` and `SIGNING_CONFIG` there, verify the workflow can access the Environment copies, delete the repository-level secrets with those same names, and require authorized reviewers;
+- verify Actions permissions allow the production workflow to prepare drafts only when explicitly dispatched.

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -1,0 +1,28 @@
+# Upstream synchronization policy
+
+Miffan is an independent project. The `upstream` remote (`rikkahub/rikkahub`) is a code input that maintainers may inspect and selectively incorporate; it is not the source of Miffan product versions, release cadence, tags, branding, package identity, or signing policy.
+
+## Sync flow
+
+1. Configure the remote once with `git config remote.upstream.tagOpt --no-tags`, then fetch the upstream code branch explicitly with `git fetch --no-tags upstream master`.
+2. Create a short-lived branch named `upstream-sync/<date-or-reference>` from current Miffan `master`.
+3. Review the upstream range and select the desired commits or merge point. Prefer a topology-preserving merge when provenance matters; use cherry-picks only when the selected scope is intentionally narrow.
+4. Resolve conflicts in favor of Miffan product identity and compatibility rules. Pay special attention to `applicationId`, deep links, signing setup, version fields, update URLs, database migrations, package namespaces, branding, and Miffan-specific UI behavior.
+5. Open an `upstream-sync` pull request into `master`. Record the upstream base and end commits, selected or excluded areas, conflict resolutions, and user-visible effects.
+6. Require normal CI (`test`, `lint`, and `assembleDebug`) and any focused compatibility tests for the affected modules before merge.
+7. Merge only after Miffan review. Delete the short-lived sync branch when normal repository policy permits.
+
+Upstream tags must not trigger Miffan builds or releases. Do not mirror, push, rewrite, or automatically propagate them to `origin`. A sync may inform release notes, but it never determines the next Miffan SemVer or `versionCode`.
+
+The persistent `remote.upstream.tagOpt` setting prevents ordinary fetches from following upstream tags. Keep `--no-tags` on explicit sync fetches as an additional safeguard.
+
+## Release notes and provenance
+
+For every Miffan release, classify the commit range by topology and keep these sections separate in both languages:
+
+- **Miffan changes**: product work authored or adapted specifically for Miffan.
+- **Synced from RikkaHub**: user-visible improvements actually incorporated by upstream syncs.
+
+Do not list an upstream commit merely because it exists in the upstream range; verify that its effective diff is present after conflict resolution. Keep commit hashes and merge mechanics in the pull request or audit notes, not in user-facing Release Notes.
+
+The independent Miffan version communicates Miffan compatibility and maturity only. Upstream provenance belongs in the sync PR and Release Notes, never in the version string.


### PR DESCRIPTION
## Summary

Establish an independent Miffan 3 release line after leaving the GitHub fork network.

- set the application version to `3.0.0-rc.1` / `178002`
- support independent SemVer releases while retaining compatibility with historical `-miffan.N` versions
- add PR/push CI and a guarded production release workflow
- isolate Nightly builds with a separate application ID and ephemeral debug signing
- document release, upstream-sync, attestation, and secret-migration policies
- add bilingual release notes that separate Miffan-owned work from upstream changes

## Release controls

The production workflow:

- requires an exact commit SHA, version name, version code, and release notes
- verifies the selected commit is reachable from `master`
- validates package identity, arm64 output, version metadata, and production certificate
- produces SHA-256 checksums and GitHub artifact attestations
- creates a draft GitHub Release instead of publishing immediately

## Verification

- `./gradlew test lint assembleDebug --stacktrace`
- `./gradlew assembleNightly --stacktrace`
- Nightly APK verified as `me.ayuilos.miffan.app.nightly`, `3.0.0-rc.1-nightly`, arm64-v8a, Android Debug signed
- all GitHub Actions YAML files parsed successfully
- `git diff --check`

## Before merge

- configure the `production` Environment and migrate `KEY_BASE64` / `SIGNING_CONFIG`
- configure `master` and release-tag protection rules
- enable immutable releases where supported
- complete a production-signed upgrade test from `2.4.11-miffan.1`
