### PR TITLE
docs: finalize 3.0.0-rc.1 release notes

### DIFF
--- a/docs/releases/3.0.0-rc.1.md
+++ b/docs/releases/3.0.0-rc.1.md
@@ -6,30 +6,34 @@
 
 ### Miffan 自有改动
 
-- 启用独立的 Miffan 3.x SemVer 版本线，并让过渡版本同时识别历史 `x.y.z-miffan.n` 与新的 SemVer，为后续 `3.0.0` 正式版升级做好准备。
-- 将 Nightly 与正式安装隔离；Nightly 使用独立包名和 CI 临时非生产签名，是一次性测试产物，不会覆盖正式版或共享其数据，也不保证不同构建间可原地升级。
+- 启用独立的 Miffan 3.x SemVer 版本线，并让过渡版本同时识别历史版本与新的 SemVer。
+- 将 Nightly 与正式安装隔离，使用独立包名和临时签名，避免覆盖正式版或共享其数据。
 - 优化软键盘弹出时的聊天输入区布局，在保持动画稳定的同时继续显示常用输入工具。
 
 ### 同步自 RikkaHub
 
+- 工作区终端支持后台运行和多标签页，并更新运行组件以改善终端兼容性。
 - 修复分支会话未继承文件夹和工作区目录的问题。
 - 提升 Skills 元数据解析的稳定性与兼容性。
 - 改进 OpenRouter 会话连续性，并兼容空的 Chat Completions 工具参数结构。
 - 补全供应商连接测试界面的本地化文本。
-- 更新工作区运行组件，改善终端环境兼容性。
+- 改善软键盘弹出时聊天输入区的布局与动画稳定性。
+- 修复 Live Update 焦点通知胶囊缺少图标的问题。
 
 Updates:
 
 ### Miffan changes
 
-- Introduced Miffan's independent 3.x SemVer line and made the transition build understand both historical `x.y.z-miffan.n` tags and new SemVer tags, preparing the path to the stable `3.0.0` update.
-- Isolated Nightly from official installations with a separate package name and ephemeral CI non-production signer. It is a disposable test artifact that cannot replace or share data with the official app, and in-place upgrades between runs are not guaranteed.
+- Introduced Miffan's independent 3.x SemVer line and made the transition build understand both historical versions and new SemVer releases.
+- Isolated Nightly from official installations with a separate package name and ephemeral signer, preventing it from replacing or sharing data with the official app.
 - Refined the chat input layout when the keyboard opens, preserving commonly used input tools while keeping the animation stable.
 
 ### Synced from RikkaHub
 
+- Added background sessions and multiple tabs to the workspace terminal, together with runtime compatibility improvements.
 - Fixed branched conversations not inheriting their folder and workspace directory.
 - Improved the stability and compatibility of Skills metadata parsing.
 - Improved OpenRouter session continuity and compatibility with empty Chat Completions tool parameter schemas.
 - Completed localization for the provider connection test interface.
-- Updated workspace runtime components for better terminal environment compatibility.
+- Improved chat input layout and animation stability when the keyboard opens.
+- Fixed the missing icon in Live Update focus notifications.


### PR DESCRIPTION
## Summary

- finalize the confirmed bilingual 3.0.0-rc.1 changelog
- add user-visible upstream workspace, IME, and notification changes
- keep Miffan-owned and upstream changes separated

## Validation

- git diff --check