### PR TITLE
build: prepare Miffan 3.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "me.ayuilos.miffan.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 178002
-        versionName = "3.0.0-rc.1"
+        versionCode = 178003
+        versionName = "3.0.0"
 
         buildConfigField("boolean", "FIREBASE_ENABLED", hasGoogleServicesConfig.toString())
 

--- a/docs/releases/3.0.0.md
+++ b/docs/releases/3.0.0.md
@@ -1,0 +1,23 @@
+# Miffan 3.0.0
+
+> Miffan 独立 3.x 发布线的首个正式版本，基于已验证的 `3.0.0-rc.1`，并正式采用标准 SemVer 版本体系。
+
+更新内容：
+
+### Miffan 自有改动
+
+- 将经过验证的 `3.0.0-rc.1` 提升为首个 3.x 正式版；除此之外，本次没有面向用户的功能变化。
+
+### 同步自 RikkaHub
+
+- 本次无面向用户的改动。
+
+Updates:
+
+### Miffan changes
+
+- Promoted the validated `3.0.0-rc.1` to the first stable 3.x release; there are no other user-facing feature changes in this release.
+
+### Synced from RikkaHub
+
+- No user-facing changes in this release.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -38,7 +38,12 @@ The first candidate in the independent line is:
 - `versionName`: `3.0.0-rc.1`
 - `versionCode`: `178002`
 
-Because the RC uses the official package name, the eventual `3.0.0` release must use a value greater than `178002`.
+The first stable release in the independent line is:
+
+- `versionName`: `3.0.0`
+- `versionCode`: `178003`
+
+Future official releases must use a `versionCode` greater than `178003`.
 
 ## Update compatibility and safety boundary
 


### PR DESCRIPTION
## Summary

- promote the validated 3.0.0-rc.1 code to stable 3.0.0
- increment Android versionCode to 178003
- add bilingual stable release notes and update release documentation

## Validation

- release range classified from 3.0.0-rc.1
- version inputs validated locally
- git diff --check