### PR TITLE
Refine update reminder experience

### DIFF
--- a/app/src/main/java/me/ayuilos/miffan/ui/components/ai/AssistantPicker.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/components/ai/AssistantPicker.kt
@@ -48,6 +48,7 @@ import me.ayuilos.miffan.Screen
 import me.ayuilos.miffan.data.datastore.Settings
 import me.ayuilos.miffan.data.model.Assistant
 import me.ayuilos.miffan.ui.components.ui.AssistantAvatar
+import me.ayuilos.miffan.ui.components.ui.MiffanMascotState
 import me.ayuilos.miffan.ui.context.LocalNavController
 import me.ayuilos.miffan.ui.hooks.rememberAssistantState
 import kotlin.uuid.Uuid
@@ -57,6 +58,7 @@ fun AssistantPicker(
     settings: Settings,
     onUpdateSettings: (Settings) -> Unit,
     modifier: Modifier = Modifier,
+    mascotState: MiffanMascotState = MiffanMascotState.Idle,
     onClickSetting: () -> Unit,
 ) {
     val state = rememberAssistantState(settings, onUpdateSettings)
@@ -82,6 +84,7 @@ fun AssistantPicker(
                 AssistantAvatar(
                     name = state.currentAssistant.name.ifEmpty { defaultAssistantName },
                     value = state.currentAssistant.avatar,
+                    semanticState = mascotState,
                     onClick = onClickSetting
                 )
             }

--- a/app/src/main/java/me/ayuilos/miffan/ui/components/ui/MiffanKindBehavior.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/components/ui/MiffanKindBehavior.kt
@@ -101,6 +101,7 @@ internal fun MiffanKindBehavior.strengthFor(
         MiffanMascotState.Thinking -> thinkingStrength
         MiffanMascotState.Happy -> happyStrength
         MiffanMascotState.Error -> errorStrength
+        MiffanMascotState.UpdateAvailable -> happyStrength * 0.7f
         MiffanMascotState.Idle -> when (inputState) {
             MiffanMascotInputState.Inactive -> idleStrength * if (dayPhase == MiffanDayPhase.Night) {
                 nightIdleMultiplier

--- a/app/src/main/java/me/ayuilos/miffan/ui/components/ui/MiffanMascot.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/components/ui/MiffanMascot.kt
@@ -66,6 +66,7 @@ enum class MiffanMascotState {
     Thinking,
     Happy,
     Error,
+    UpdateAvailable,
 }
 
 enum class MiffanMascotInputState {
@@ -611,6 +612,7 @@ fun MiffanMascot(
         targetValue = when (state) {
             MiffanMascotState.Happy -> -5f * motion.stateAmplitude
             MiffanMascotState.Error -> 6f * motion.stateAmplitude
+            MiffanMascotState.UpdateAvailable -> -2f * motion.stateAmplitude
             else -> 0f
         },
         animationSpec = spring(dampingRatio = 0.48f, stiffness = Spring.StiffnessMediumLow),
@@ -696,6 +698,7 @@ fun MiffanMascot(
             MiffanMascotState.Thinking ->
                 sin(Math.toRadians(thinkingPhase.toDouble())).toFloat() * motion.thinkingBob
             MiffanMascotState.Happy -> -breath * motion.happyBob
+            MiffanMascotState.UpdateAvailable -> -breath * motion.happyBob * 0.45f
             else -> {
                 val breathAmplitude = when (dayPhase) {
                     MiffanDayPhase.Morning -> 1.3f
@@ -722,12 +725,14 @@ fun MiffanMascot(
             MiffanMascotState.Thinking ->
                 sin(thinkingRadians).toFloat() * 4.5f * motion.gazeAmplitude
             MiffanMascotState.Error -> -2f
+            MiffanMascotState.UpdateAvailable -> 3f * motion.gazeAmplitude
             else -> gazeX.value
         }
         val ambientLookY = when (state) {
             MiffanMascotState.Thinking ->
                 cos(thinkingRadians * 0.7).toFloat() * 1.8f * motion.gazeAmplitude
             MiffanMascotState.Error -> 2f
+            MiffanMascotState.UpdateAvailable -> -2f * motion.gazeAmplitude
             else -> gazeY.value
         }
         val inputLookWeight = inputFocusProgress * (1f - pokeExpression.value)
@@ -792,6 +797,14 @@ fun MiffanMascot(
                 )
             }
 
+            if (state == MiffanMascotState.UpdateAvailable) {
+                drawUpdateAvailableCue(
+                    colors = colors,
+                    pulse = inputPulse,
+                    amplitude = motion.stateAmplitude,
+                )
+            }
+
             if (state == MiffanMascotState.Idle) {
                 drawInputCue(
                     colors = colors,
@@ -803,6 +816,49 @@ fun MiffanMascot(
                 )
             }
         }
+    }
+}
+
+private fun DrawScope.drawUpdateAvailableCue(
+    colors: MiffanColors,
+    pulse: Float,
+    amplitude: Float,
+) {
+    val center = Offset(156f, 43f)
+    val pulseScale = 0.92f + pulse * 0.08f * amplitude
+    withTransform({ scale(pulseScale, pulseScale, pivot = center) }) {
+        drawCircle(
+            color = colors.cueSurface,
+            radius = 17f,
+            center = center,
+        )
+        drawCircle(
+            color = colors.cueInk.copy(alpha = 0.28f),
+            radius = 17f,
+            center = center,
+            style = Stroke(width = 3f),
+        )
+        drawLine(
+            color = colors.cueInk,
+            start = Offset(156f, 34f),
+            end = Offset(156f, 51f),
+            strokeWidth = 5f,
+            cap = StrokeCap.Round,
+        )
+        drawLine(
+            color = colors.cueInk,
+            start = Offset(149f, 45f),
+            end = Offset(156f, 52f),
+            strokeWidth = 5f,
+            cap = StrokeCap.Round,
+        )
+        drawLine(
+            color = colors.cueInk,
+            start = Offset(163f, 45f),
+            end = Offset(156f, 52f),
+            strokeWidth = 5f,
+            cap = StrokeCap.Round,
+        )
     }
 }
 
@@ -1470,7 +1526,8 @@ private fun DrawScope.drawMascotBody(
     }
 
     when (state) {
-        MiffanMascotState.Happy -> {
+        MiffanMascotState.Happy,
+        MiffanMascotState.UpdateAvailable -> {
             drawArc(
                 color = restingMouthColor,
                 startAngle = 12f,

--- a/app/src/main/java/me/ayuilos/miffan/ui/components/ui/UIAvatar.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/components/ui/UIAvatar.kt
@@ -365,6 +365,7 @@ fun AssistantAvatar(
     value: Avatar,
     modifier: Modifier = Modifier,
     loading: Boolean = false,
+    semanticState: MiffanMascotState = MiffanMascotState.Idle,
     onUpdate: ((Avatar) -> Unit)? = null,
     onClick: (() -> Unit)? = null,
 ) {
@@ -403,11 +404,11 @@ fun AssistantAvatar(
         }
     }
 
-    val mascotState = when {
-        loading -> MiffanMascotState.Thinking
-        showingCompletion -> MiffanMascotState.Happy
-        else -> MiffanMascotState.Idle
-    }
+    val mascotState = resolveAssistantMascotState(
+        loading = loading,
+        showingCompletion = showingCompletion,
+        semanticState = semanticState,
+    )
     UIAvatar(
         name = name,
         value = Avatar.Dummy,
@@ -425,6 +426,16 @@ fun AssistantAvatar(
             )
         },
     )
+}
+
+internal fun resolveAssistantMascotState(
+    loading: Boolean,
+    showingCompletion: Boolean,
+    semanticState: MiffanMascotState,
+): MiffanMascotState = when {
+    loading -> MiffanMascotState.Thinking
+    showingCompletion -> MiffanMascotState.Happy
+    else -> semanticState
 }
 
 @Composable

--- a/app/src/main/java/me/ayuilos/miffan/ui/components/ui/UpdateCard.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/components/ui/UpdateCard.kt
@@ -2,17 +2,16 @@ package me.ayuilos.miffan.ui.components.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedCard
@@ -26,26 +25,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dokar.sonner.ToastType
 import me.rerere.hugeicons.HugeIcons
-import me.rerere.hugeicons.stroke.Cancel01
+import me.rerere.hugeicons.stroke.ArrowRight01
 import me.rerere.hugeicons.stroke.Download01
-import me.ayuilos.miffan.BuildConfig
 import me.ayuilos.miffan.R
 import me.ayuilos.miffan.ui.components.richtext.MarkdownBlock
 import me.ayuilos.miffan.ui.context.LocalToaster
 import me.ayuilos.miffan.ui.hooks.useThrottle
-import me.ayuilos.miffan.ui.pages.chat.ChatVM
 import me.ayuilos.miffan.utils.UpdateDownload
-import me.ayuilos.miffan.utils.Version
+import me.ayuilos.miffan.utils.UpdateInfo
 import me.ayuilos.miffan.utils.fileSizeToString
-import me.ayuilos.miffan.utils.onError
-import me.ayuilos.miffan.utils.onSuccess
 import me.ayuilos.miffan.utils.openUrl
 import me.ayuilos.miffan.utils.toLocalDateTime
 import kotlin.time.ExperimentalTime
@@ -54,141 +49,108 @@ import kotlin.time.toJavaInstant
 
 @OptIn(ExperimentalTime::class)
 @Composable
-fun UpdateCard(vm: ChatVM) {
-    val state by vm.updateState.collectAsStateWithLifecycle()
+fun UpdateAvailableBanner(
+    info: UpdateInfo,
+    onDownload: (UpdateDownload) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
     val toaster = LocalToaster.current
     val downloadingMessage = stringResource(R.string.update_card_downloading)
-    state.onError {
-        Card {
+    var showDetail by remember { mutableStateOf(false) }
+
+    Card(
+        onClick = { showDetail = true },
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        ListItem(
+            headlineContent = {
+                Text(
+                    text = stringResource(R.string.update_card_new_version_found, info.version),
+                    style = MaterialTheme.typography.titleSmall,
+                )
+            },
+            leadingContent = {
+                Icon(
+                    imageVector = HugeIcons.Download01,
+                    contentDescription = null,
+                )
+            },
+            trailingContent = {
+                Icon(
+                    imageVector = HugeIcons.ArrowRight01,
+                    contentDescription = null,
+                )
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        )
+    }
+
+    if (showDetail) {
+        val downloadHandler = useThrottle<UpdateDownload>(500) { item ->
+            onDownload(item)
+            showDetail = false
+            toaster.show(downloadingMessage, type = ToastType.Info)
+        }
+        ModalBottomSheet(
+            onDismissRequest = { showDetail = false },
+            sheetState = rememberBottomSheetState(
+                initialValue = SheetValue.Hidden,
+                enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+            ),
+        ) {
             Column(
                 modifier = Modifier
-                    .padding(8.dp)
-                    .fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 32.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
-                    text = stringResource(R.string.update_card_check_failed),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.error
+                    text = info.version,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.primary,
                 )
                 Text(
-                    text = it.message ?: stringResource(R.string.update_card_unknown_error),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
+                    text = Instant.parse(info.publishedAt).toJavaInstant().toLocalDateTime(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
                 )
-            }
-        }
-    }
-    state.onSuccess { info ->
-        var showDetail by remember { mutableStateOf(false) }
-        var dismissed by remember { mutableStateOf(false) }
-        val current = remember { Version(BuildConfig.VERSION_NAME) }
-        val latest = remember(info) { Version(info.version) }
-        if (latest > current && !dismissed) {
-            Card(
-                onClick = {
-                    showDetail = true
-                }
-            ) {
-                Column(
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = stringResource(R.string.update_card_new_version_found, info.version),
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.weight(1f)
-                        )
-                        IconButton(onClick = { dismissed = true }) {
-                            Icon(
-                                imageVector = HugeIcons.Cancel01,
-                                contentDescription = stringResource(R.string.update_card_close),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                    MarkdownBlock(
-                        content = info.changelog,
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.heightIn(max = 200.dp)
-                    )
-                }
-            }
-        }
-        if (showDetail) {
-            val downloadHandler = useThrottle<UpdateDownload>(500) { item ->
-                vm.updateChecker.downloadUpdate(context, item)
-                showDetail = false
-                toaster.show(downloadingMessage, type = ToastType.Info)
-            }
-            ModalBottomSheet(
-                onDismissRequest = { showDetail = false },
-                sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden, enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)),
-            ) {
-                Column(
+                MarkdownBlock(
+                    content = info.changelog,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 32.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = info.version,
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    Text(
-                        text = Instant.parse(info.publishedAt).toJavaInstant().toLocalDateTime(),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    MarkdownBlock(
-                        content = info.changelog,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(300.dp)
-                            .verticalScroll(rememberScrollState()),
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                    info.downloads.fastForEach { downloadItem ->
-                        OutlinedCard(
-                            onClick = {
-                                downloadHandler(downloadItem)
-                            },
-                        ) {
-                            ListItem(
-                                headlineContent = {
-                                    Text(
-                                        text = downloadItem.name,
-                                    )
-                                },
-                                supportingContent = downloadItem.sizeBytes?.let { size ->
-                                    { Text(text = size.fileSizeToString()) }
-                                },
-                                leadingContent = {
-                                    Icon(
-                                        imageVector = HugeIcons.Download01,
-                                        contentDescription = null
-                                    )
-                                }
-                            )
-                        }
-                    }
-                    OutlinedCard(onClick = { context.openUrl(info.releaseUrl) }) {
+                        .height(300.dp)
+                        .verticalScroll(rememberScrollState()),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                info.downloads.fastForEach { downloadItem ->
+                    OutlinedCard(
+                        onClick = { downloadHandler(downloadItem) },
+                    ) {
                         ListItem(
-                            headlineContent = { Text("GitHub Release") },
-                            supportingContent = { Text(info.releaseUrl) },
+                            headlineContent = { Text(text = downloadItem.name) },
+                            supportingContent = downloadItem.sizeBytes?.let { size ->
+                                { Text(text = size.fileSizeToString()) }
+                            },
+                            leadingContent = {
+                                Icon(
+                                    imageVector = HugeIcons.Download01,
+                                    contentDescription = null,
+                                )
+                            },
                         )
                     }
+                }
+                OutlinedCard(onClick = { context.openUrl(info.releaseUrl) }) {
+                    ListItem(
+                        headlineContent = { Text("GitHub Release") },
+                        supportingContent = { Text(info.releaseUrl) },
+                    )
                 }
             }
         }

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatDrawer.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -19,6 +20,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Badge
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -50,7 +52,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -80,9 +81,9 @@ import me.ayuilos.miffan.ui.components.ai.AssistantPicker
 import me.ayuilos.miffan.ui.components.ui.AssistantAvatar
 import me.ayuilos.miffan.ui.components.ui.BackupReminderCard
 import me.ayuilos.miffan.ui.components.ui.Greeting
+import me.ayuilos.miffan.ui.components.ui.MiffanMascotState
 import me.ayuilos.miffan.ui.components.ui.Tooltip
 import me.ayuilos.miffan.ui.components.ui.UIAvatar
-import me.ayuilos.miffan.ui.components.ui.UpdateCard
 import androidx.compose.ui.draw.clip
 import me.ayuilos.miffan.ui.context.LocalToaster
 import me.ayuilos.miffan.ui.context.Navigator
@@ -110,6 +111,11 @@ fun ChatDrawerContent(
     val resources = LocalResources.current
     val toaster = LocalToaster.current
     val isPlayStore = rememberIsPlayStoreVersion()
+    val availableUpdate = if (isPlayStore) {
+        null
+    } else {
+        vm.availableUpdate.collectAsStateWithLifecycle().value
+    }
     val repo = koinInject<ConversationRepository>()
 
     val activity = context as ComponentActivity
@@ -165,22 +171,6 @@ fun ChatDrawerContent(
     // Menu popup 状态
     var showMenuPopup by remember { mutableStateOf(false) }
 
-    val updateCheckDisabledUntil = settings.displaySetting.updateCheckDisabledUntilEpochMillis
-    var updateChecksEnabled by remember(updateCheckDisabledUntil) {
-        mutableStateOf(updateCheckDisabledUntil <= System.currentTimeMillis())
-    }
-    LaunchedEffect(updateCheckDisabledUntil) {
-        while (true) {
-            val remaining = updateCheckDisabledUntil - System.currentTimeMillis()
-            if (remaining <= 0) {
-                updateChecksEnabled = true
-                break
-            }
-            updateChecksEnabled = false
-            delay(minOf(remaining, 60 * 60 * 1_000L))
-        }
-    }
-
     ModalDrawerSheet(
         modifier = Modifier.width(300.dp)
     ) {
@@ -188,10 +178,6 @@ fun ChatDrawerContent(
             modifier = Modifier.padding(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            if (updateChecksEnabled && !isPlayStore) {
-                UpdateCard(vm)
-            }
-
             BackupReminderCard(
                 settings = settings,
                 onClick = { navController.navigate(Screen.Backup) },
@@ -304,6 +290,11 @@ fun ChatDrawerContent(
             // 助手选择器
             AssistantPicker(
                 settings = settings,
+                mascotState = if (availableUpdate != null) {
+                    MiffanMascotState.UpdateAvailable
+                } else {
+                    MiffanMascotState.Idle
+                },
                 onUpdateSettings = {
                     val updateJob = vm.updateSettings(it)
                     scope.launch {
@@ -411,7 +402,28 @@ fun ChatDrawerContent(
 
                 DrawerAction(
                     icon = {
-                        Icon(HugeIcons.Settings03, null)
+                        val contentDescription = availableUpdate?.let { info ->
+                            stringResource(R.string.update_card_new_version_found, info.version)
+                        } ?: stringResource(R.string.settings)
+                        Box(
+                            modifier = Modifier.size(20.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = HugeIcons.Settings03,
+                                contentDescription = contentDescription,
+                                modifier = Modifier.size(20.dp),
+                            )
+                            if (availableUpdate != null) {
+                                Badge(
+                                    modifier = Modifier
+                                        .align(Alignment.TopEnd)
+                                        .offset(x = 3.dp, y = (-3).dp)
+                                        .size(8.dp),
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        }
                     },
                     label = { Text(stringResource(R.string.settings)) },
                     onClick = {

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatList.kt
@@ -136,6 +136,7 @@ fun ChatList(
     settings: Settings,
     hazeState: HazeState,
     errors: List<ChatError> = emptyList(),
+    mascotSemanticState: MiffanMascotState = MiffanMascotState.Idle,
     mascotInputState: MiffanMascotInputState = MiffanMascotInputState.Inactive,
     mascotSubmitId: Int = 0,
     onDismissError: (Uuid) -> Unit = {},
@@ -181,6 +182,7 @@ fun ChatList(
                 settings = settings,
                 hazeState = hazeState,
                 errors = errors,
+                mascotSemanticState = mascotSemanticState,
                 mascotInputState = mascotInputState,
                 mascotSubmitId = mascotSubmitId,
                 onDismissError = onDismissError,
@@ -213,6 +215,7 @@ private fun ChatListNormal(
     settings: Settings,
     hazeState: HazeState,
     errors: List<ChatError>,
+    mascotSemanticState: MiffanMascotState,
     mascotInputState: MiffanMascotInputState,
     mascotSubmitId: Int,
     onDismissError: (Uuid) -> Unit,
@@ -517,7 +520,10 @@ private fun ChatListNormal(
             ) {
                 if (assistant == null || assistant.avatar.isMiffanAvatar()) {
                     MiffanMascot(
-                        state = if (errors.isEmpty()) MiffanMascotState.Idle else MiffanMascotState.Error,
+                        state = resolveChatMascotState(
+                            hasErrors = errors.isNotEmpty(),
+                            semanticState = mascotSemanticState,
+                        ),
                         appearance = assistant?.avatar?.miffanAppearanceOrDefault()
                             ?: MiffanAppearance(),
                         motionProfile = assistant?.avatar?.miffanMotionProfileOrDefault()
@@ -654,6 +660,15 @@ private fun ChatListNormal(
             }
         }
     }
+}
+
+internal fun resolveChatMascotState(
+    hasErrors: Boolean,
+    semanticState: MiffanMascotState,
+): MiffanMascotState = if (hasErrors) {
+    MiffanMascotState.Error
+} else {
+    semanticState
 }
 
 /**

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatPage.kt
@@ -88,6 +88,7 @@ import me.ayuilos.miffan.ui.components.ai.SearchMode
 import me.ayuilos.miffan.ui.components.ai.completion.WorkspaceCompletionProvider
 import me.ayuilos.miffan.ui.components.ai.useCropLauncher
 import me.ayuilos.miffan.ui.components.ui.MiffanMascotInputState
+import me.ayuilos.miffan.ui.components.ui.MiffanMascotState
 import me.ayuilos.miffan.ui.components.ui.permission.PermissionCamera
 import me.ayuilos.miffan.ui.components.ui.permission.PermissionManager
 import me.ayuilos.miffan.ui.components.ui.permission.rememberPermissionState
@@ -96,6 +97,7 @@ import me.ayuilos.miffan.ui.context.LocalToaster
 import me.ayuilos.miffan.ui.context.Navigator
 import me.ayuilos.miffan.ui.hooks.ChatInputState
 import me.ayuilos.miffan.ui.hooks.EditStateContent
+import me.ayuilos.miffan.ui.hooks.rememberIsPlayStoreVersion
 import me.ayuilos.miffan.ui.hooks.useEditState
 import me.ayuilos.miffan.utils.ImageUtils
 import me.ayuilos.miffan.utils.base64Decode
@@ -126,6 +128,13 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
     val currentChatModel by vm.currentChatModel.collectAsStateWithLifecycle()
     val enableWebSearch by vm.enableWebSearch.collectAsStateWithLifecycle()
     val errors by vm.errors.collectAsStateWithLifecycle()
+    val availableUpdate by vm.availableUpdate.collectAsStateWithLifecycle()
+    val isPlayStore = rememberIsPlayStoreVersion()
+    val mascotSemanticState = if (!isPlayStore && availableUpdate != null) {
+        MiffanMascotState.UpdateAvailable
+    } else {
+        MiffanMascotState.Idle
+    }
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val softwareKeyboardController = LocalSoftwareKeyboardController.current
@@ -227,6 +236,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
                     currentChatModel = currentChatModel,
                     bigScreen = true,
                     errors = errors,
+                    mascotSemanticState = mascotSemanticState,
                     onDismissError = { vm.dismissError(it) },
                     onClearAllErrors = { vm.clearAllErrors() },
                 )
@@ -259,6 +269,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
                     currentChatModel = currentChatModel,
                     bigScreen = false,
                     errors = errors,
+                    mascotSemanticState = mascotSemanticState,
                     onDismissError = { vm.dismissError(it) },
                     onClearAllErrors = { vm.clearAllErrors() },
                 )
@@ -285,6 +296,7 @@ private fun ChatPageContent(
     enableWebSearch: Boolean,
     currentChatModel: Model?,
     errors: List<ChatError>,
+    mascotSemanticState: MiffanMascotState,
     onDismissError: (Uuid) -> Unit,
     onClearAllErrors: () -> Unit,
 ) {
@@ -472,6 +484,7 @@ private fun ChatPageContent(
                 settings = setting,
                 hazeState = hazeState,
                 errors = errors,
+                mascotSemanticState = mascotSemanticState,
                 mascotInputState = mascotInputState,
                 mascotSubmitId = mascotSubmitId,
                 onDismissError = onDismissError,

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatVM.kt
@@ -15,9 +15,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -43,8 +40,8 @@ import me.ayuilos.miffan.service.ChatService
 import me.ayuilos.miffan.ui.hooks.writeStringPreference
 import me.ayuilos.miffan.ui.hooks.ChatInputState
 import me.ayuilos.miffan.utils.AppAnalytics
-import me.ayuilos.miffan.utils.UiState
 import me.ayuilos.miffan.utils.UpdateChecker
+import me.ayuilos.miffan.utils.availableUpdate
 import java.util.Locale
 import kotlin.uuid.Uuid
 
@@ -167,19 +164,12 @@ class ChatVM(
     }
 
     // Update checker
-    val updateState = settingsStore.settingsFlow
-        .map { settings ->
-            !settings.init &&
-                settings.displaySetting.updateCheckDisabledUntilEpochMillis <= System.currentTimeMillis()
-        }
-        .distinctUntilChanged()
-        .flatMapLatest { enabled ->
-            if (enabled) updateChecker.updateState else flowOf(UiState.Loading)
-        }
+    val availableUpdate = updateChecker.observeUpdateState(settingsStore.settingsFlow)
+        .map { it.availableUpdate() }
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
-            UiState.Loading,
+            null,
         )
 
     /**

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/debug/DebugPage.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/debug/DebugPage.kt
@@ -54,6 +54,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dokar.sonner.ToastType
 import kotlinx.coroutines.launch
 import me.rerere.common.android.Logging
+import me.ayuilos.miffan.BuildConfig
+import me.ayuilos.miffan.Screen
 import me.ayuilos.miffan.data.model.Avatar
 import me.ayuilos.miffan.data.model.MiffanAppearance
 import me.ayuilos.miffan.data.model.MiffanColorSource
@@ -73,6 +75,7 @@ import me.ayuilos.miffan.ui.components.richtext.MarkdownBlock
 import me.ayuilos.miffan.ui.components.richtext.MathBlock
 import me.ayuilos.miffan.ui.components.richtext.Mermaid
 import me.ayuilos.miffan.ui.context.LocalSettings
+import me.ayuilos.miffan.ui.context.LocalNavController
 import me.ayuilos.miffan.ui.context.LocalToaster
 import me.ayuilos.miffan.ui.theme.JetbrainsMono
 import org.koin.androidx.compose.koinViewModel
@@ -178,6 +181,7 @@ private enum class MiffanLabMode(
     Thinking("Thinking", mascotState = MiffanMascotState.Thinking),
     Happy("Happy", mascotState = MiffanMascotState.Happy),
     Error("Error", mascotState = MiffanMascotState.Error),
+    UpdateAvailable("Update available", mascotState = MiffanMascotState.UpdateAvailable),
     Focused("Focused", inputState = MiffanMascotInputState.Focused),
     Typing("Typing", inputState = MiffanMascotInputState.Typing),
 }
@@ -414,6 +418,7 @@ private fun MiffanLabPage() {
 @Composable
 private fun MainPage(vm: DebugVM) {
     val settings = LocalSettings.current
+    val navController = LocalNavController.current
     val conversationCount by vm.conversationCount.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier
@@ -422,6 +427,37 @@ private fun MainPage(vm: DebugVM) {
             .imePadding(),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
+        if (BuildConfig.DEBUG) {
+            val debugUpdateOverrideEnabled by
+                vm.debugUpdateOverrideEnabled.collectAsStateWithLifecycle()
+            Text("Update reminder preview", style = MaterialTheme.typography.titleSmall)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Simulate an available update")
+                    Text(
+                        "Affects the drawer badge, current Miffan avatar, and settings banner.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = debugUpdateOverrideEnabled,
+                    onCheckedChange = vm::setDebugUpdateOverrideEnabled,
+                )
+            }
+            Button(
+                enabled = debugUpdateOverrideEnabled,
+                onClick = { navController.navigate(Screen.Setting) },
+            ) {
+                Text("Open Settings preview")
+            }
+            HorizontalDivider()
+        }
+
         val phaseOverride by MiffanDayPhaseDebugOverride.phase.collectAsState()
         val effectivePhase = rememberMiffanDayPhase()
         val phaseOptions = listOf<MiffanDayPhase?>(

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/debug/DebugVM.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/debug/DebugVM.kt
@@ -17,6 +17,7 @@ import me.ayuilos.miffan.data.datastore.SettingsStore
 import me.ayuilos.miffan.data.model.Conversation
 import me.ayuilos.miffan.data.model.MessageNode
 import me.ayuilos.miffan.data.repository.ConversationRepository
+import me.ayuilos.miffan.utils.UpdateChecker
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
@@ -26,12 +27,15 @@ import kotlin.uuid.Uuid
 class DebugVM(
     private val settingsStore: SettingsStore,
     private val conversationRepository: ConversationRepository,
+    private val updateChecker: UpdateChecker,
 ) : ViewModel() {
     val settings: StateFlow<Settings> = settingsStore.settingsFlow
         .stateIn(viewModelScope, SharingStarted.Lazily, Settings.dummy())
 
     private val _conversationCount = MutableStateFlow<Int?>(null)
     val conversationCount: StateFlow<Int?> = _conversationCount.asStateFlow()
+    val debugUpdateOverrideEnabled: StateFlow<Boolean> =
+        updateChecker.debugUpdateOverrideEnabled
 
     init {
         refreshConversationCount()
@@ -47,6 +51,10 @@ class DebugVM(
         viewModelScope.launch {
             settingsStore.update(settings)
         }
+    }
+
+    fun setDebugUpdateOverrideEnabled(enabled: Boolean) {
+        updateChecker.setDebugUpdateOverrideEnabled(enabled)
     }
 
     /**

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/setting/SettingPage.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/setting/SettingPage.kt
@@ -63,9 +63,11 @@ import me.ayuilos.miffan.data.files.FilesManager
 import me.ayuilos.miffan.ui.components.nav.BackButton
 import me.ayuilos.miffan.ui.components.ui.CardGroup
 import me.ayuilos.miffan.ui.components.ui.Select
+import me.ayuilos.miffan.ui.components.ui.UpdateAvailableBanner
 import me.ayuilos.miffan.ui.context.LocalNavController
 import me.ayuilos.miffan.ui.context.Navigator
 import me.ayuilos.miffan.ui.hooks.rememberColorMode
+import me.ayuilos.miffan.ui.hooks.rememberIsPlayStoreVersion
 import me.ayuilos.miffan.ui.theme.ColorMode
 import me.ayuilos.miffan.ui.theme.CustomColors
 import me.ayuilos.miffan.utils.openUrl
@@ -78,6 +80,12 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val navController = LocalNavController.current
     val settings by vm.settings.collectAsStateWithLifecycle()
+    val isPlayStore = rememberIsPlayStoreVersion()
+    val availableUpdate = if (isPlayStore) {
+        null
+    } else {
+        vm.availableUpdate.collectAsStateWithLifecycle().value
+    }
     val filesManager: FilesManager = koinInject()
 
     Scaffold(
@@ -101,6 +109,17 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
             contentPadding = innerPadding + PaddingValues(8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            availableUpdate?.let { info ->
+                item("availableUpdate") {
+                    val context = LocalContext.current
+                    UpdateAvailableBanner(
+                        info = info,
+                        onDownload = { vm.downloadUpdate(context, it) },
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                    )
+                }
+            }
+
             if (settings.isNotConfigured()) {
                 item {
                     ProviderConfigWarningCard(navController)

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/setting/SettingVM.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/setting/SettingVM.kt
@@ -1,26 +1,46 @@
 package me.ayuilos.miffan.ui.pages.setting
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import me.ayuilos.miffan.data.ai.mcp.McpManager
 import me.ayuilos.miffan.data.datastore.Settings
 import me.ayuilos.miffan.data.datastore.SettingsStore
-import me.ayuilos.miffan.data.ai.mcp.McpManager
+import me.ayuilos.miffan.utils.UpdateChecker
+import me.ayuilos.miffan.utils.UpdateDownload
+import me.ayuilos.miffan.utils.UpdateInfo
+import me.ayuilos.miffan.utils.availableUpdate
 
 class SettingVM(
     private val settingsStore: SettingsStore,
-    private val mcpManager: McpManager
+    private val mcpManager: McpManager,
+    private val updateChecker: UpdateChecker,
 ) :
     ViewModel() {
     val settings: StateFlow<Settings> = settingsStore.settingsFlow
         .stateIn(viewModelScope, SharingStarted.Lazily, Settings(init = true, providers = emptyList()))
 
+    val availableUpdate: StateFlow<UpdateInfo?> =
+        updateChecker.observeUpdateState(settingsStore.settingsFlow)
+            .map { it.availableUpdate() }
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                null,
+            )
+
     fun updateSettings(settings: Settings) {
         viewModelScope.launch {
             settingsStore.update(settings)
         }
+    }
+
+    fun downloadUpdate(context: Context, download: UpdateDownload) {
+        updateChecker.downloadUpdate(context, download)
     }
 }

--- a/app/src/main/java/me/ayuilos/miffan/utils/UpdateChecker.kt
+++ b/app/src/main/java/me/ayuilos/miffan/utils/UpdateChecker.kt
@@ -8,11 +8,17 @@ import android.widget.Toast
 import androidx.core.net.toUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
@@ -21,6 +27,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import me.ayuilos.miffan.AppScope
 import me.ayuilos.miffan.BuildConfig
+import me.ayuilos.miffan.data.datastore.Settings
 import me.rerere.common.http.await
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -34,6 +41,8 @@ private const val GITHUB_RELEASE_ATOM_URL =
     "https://github.com/Ayuilos/Miffan/releases.atom"
 private const val GITHUB_RELEASES_URL =
     "https://github.com/Ayuilos/Miffan/releases"
+private const val DEBUG_UPDATE_VERSION = "999.0.0-debug-preview"
+private const val DEBUG_UPDATE_PUBLISHED_AT = "2026-08-26T00:00:00Z"
 private const val SEMVER_NUMERIC_IDENTIFIER = "(?:0|[1-9]\\d*)"
 private const val SEMVER_NON_NUMERIC_IDENTIFIER = "(?:\\d*[A-Za-z-][0-9A-Za-z-]*)"
 private const val SEMVER_PRERELEASE_IDENTIFIER =
@@ -55,12 +64,48 @@ class UpdateChecker(
     appScope: AppScope,
 ) {
     private val releaseSource = GitHubReleaseSource(client)
+    private val _debugUpdateOverrideEnabled = MutableStateFlow(false)
+    val debugUpdateOverrideEnabled: StateFlow<Boolean> =
+        _debugUpdateOverrideEnabled.asStateFlow()
 
-    val updateState: StateFlow<UiState<UpdateInfo>> = checkUpdate().stateIn(
-        scope = appScope,
-        started = SharingStarted.Lazily,
-        initialValue = UiState.Loading,
-    )
+    val updateState: StateFlow<UiState<UpdateInfo>> =
+        combine(checkUpdate(), debugUpdateOverrideEnabled) { state, debugOverrideEnabled ->
+            state.withDebugUpdateOverride(
+                enabled = BuildConfig.DEBUG && debugOverrideEnabled,
+            )
+        }.stateIn(
+            scope = appScope,
+            started = SharingStarted.Lazily,
+            initialValue = UiState.Loading,
+        )
+
+    fun observeUpdateState(settings: Flow<Settings>): Flow<UiState<UpdateInfo>> =
+        combine(settings, debugUpdateOverrideEnabled) { currentSettings, debugOverrideEnabled ->
+            currentSettings to (BuildConfig.DEBUG && debugOverrideEnabled)
+        }.flatMapLatest { (currentSettings, debugOverrideEnabled) ->
+            flow {
+                if (currentSettings.init) {
+                    emit(UiState.Loading)
+                    return@flow
+                }
+
+                val disabledUntil =
+                    currentSettings.displaySetting.updateCheckDisabledUntilEpochMillis
+                val now = System.currentTimeMillis()
+                if (!debugOverrideEnabled && disabledUntil > now) {
+                    emit(UiState.Loading)
+                    delay(disabledUntil - now)
+                }
+
+                emitAll(updateState)
+            }
+        }
+
+    fun setDebugUpdateOverrideEnabled(enabled: Boolean) {
+        if (BuildConfig.DEBUG) {
+            _debugUpdateOverrideEnabled.value = enabled
+        }
+    }
 
     private fun checkUpdate(): Flow<UiState<UpdateInfo>> = flow {
         emit(UiState.Loading)
@@ -118,6 +163,33 @@ data class UpdateInfo(
     val downloads: List<UpdateDownload>,
     val releaseUrl: String,
 )
+
+fun UiState<UpdateInfo>.availableUpdate(
+    currentVersion: String = BuildConfig.VERSION_NAME,
+): UpdateInfo? = (this as? UiState.Success)?.data?.takeIf { info ->
+    Version(info.version) > Version(currentVersion)
+}
+
+internal fun UiState<UpdateInfo>.withDebugUpdateOverride(
+    enabled: Boolean,
+): UiState<UpdateInfo> {
+    if (!enabled) return this
+    val releaseInfo = (this as? UiState.Success)?.data
+    return UiState.Success(
+        UpdateInfo(
+            version = DEBUG_UPDATE_VERSION,
+            publishedAt = releaseInfo?.publishedAt ?: DEBUG_UPDATE_PUBLISHED_AT,
+            changelog = """
+                ## Debug update preview
+
+                This local preview exercises the update badge, settings banner, detail sheet,
+                and Miffan semantic state. No fake APK download is provided.
+            """.trimIndent(),
+            downloads = emptyList(),
+            releaseUrl = releaseInfo?.releaseUrl ?: GITHUB_RELEASES_URL,
+        )
+    )
+}
 
 internal class GitHubReleaseSource(
     private val client: OkHttpClient,

--- a/app/src/test/java/me/ayuilos/miffan/ui/components/ui/AssistantAvatarStateTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/ui/components/ui/AssistantAvatarStateTest.kt
@@ -1,0 +1,38 @@
+package me.ayuilos.miffan.ui.components.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AssistantAvatarStateTest {
+    @Test
+    fun semanticUpdateStateReachesIdleAssistantAvatar() {
+        assertEquals(
+            MiffanMascotState.UpdateAvailable,
+            resolveAssistantMascotState(
+                loading = false,
+                showingCompletion = false,
+                semanticState = MiffanMascotState.UpdateAvailable,
+            ),
+        )
+    }
+
+    @Test
+    fun transientConversationStatesTakePriorityOverUpdateState() {
+        assertEquals(
+            MiffanMascotState.Thinking,
+            resolveAssistantMascotState(
+                loading = true,
+                showingCompletion = false,
+                semanticState = MiffanMascotState.UpdateAvailable,
+            ),
+        )
+        assertEquals(
+            MiffanMascotState.Happy,
+            resolveAssistantMascotState(
+                loading = false,
+                showingCompletion = true,
+                semanticState = MiffanMascotState.UpdateAvailable,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/me/ayuilos/miffan/ui/components/ui/MiffanKindBehaviorTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/ui/components/ui/MiffanKindBehaviorTest.kt
@@ -29,6 +29,22 @@ class MiffanKindBehaviorTest {
     }
 
     @Test
+    fun updateAvailableIsAnActiveButRestrainedCharacterState() {
+        MiffanKind.entries.forEach { kind ->
+            val behavior = kind.miffanKindBehavior()
+            val updateStrength = behavior.strengthFor(
+                state = MiffanMascotState.UpdateAvailable,
+                inputState = MiffanMascotInputState.Inactive,
+                dayPhase = MiffanDayPhase.Noon,
+                submitProgress = 0f,
+            )
+
+            assertTrue(updateStrength > behavior.idleStrength)
+            assertTrue(updateStrength < behavior.happyStrength)
+        }
+    }
+
+    @Test
     fun dumplingSignatureUsesAGentleCycle() {
         val behavior = MiffanKind.DUMPLING.miffanKindBehavior()
 

--- a/app/src/test/java/me/ayuilos/miffan/ui/pages/chat/ChatMascotStateTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/ui/pages/chat/ChatMascotStateTest.kt
@@ -1,0 +1,29 @@
+package me.ayuilos.miffan.ui.pages.chat
+
+import me.ayuilos.miffan.ui.components.ui.MiffanMascotState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatMascotStateTest {
+    @Test
+    fun availableUpdateReachesChatMascot() {
+        assertEquals(
+            MiffanMascotState.UpdateAvailable,
+            resolveChatMascotState(
+                hasErrors = false,
+                semanticState = MiffanMascotState.UpdateAvailable,
+            ),
+        )
+    }
+
+    @Test
+    fun chatErrorTakesPriorityOverAvailableUpdate() {
+        assertEquals(
+            MiffanMascotState.Error,
+            resolveChatMascotState(
+                hasErrors = true,
+                semanticState = MiffanMascotState.UpdateAvailable,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/me/ayuilos/miffan/utils/VersionTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/utils/VersionTest.kt
@@ -93,4 +93,34 @@ class VersionTest {
         assertTrue("1.0.0" < Version("2.0.0"))
         assertTrue(Version("2.0.0") > "1.0.0")
     }
+
+    @Test
+    fun `available update only returns newer successful releases`() {
+        val newer = updateInfo("3.1.0")
+
+        assertEquals(newer, UiState.Success(newer).availableUpdate("3.0.0"))
+        assertEquals(null, UiState.Success(updateInfo("3.0.0")).availableUpdate("3.0.0"))
+        assertEquals(null, UiState.Success(updateInfo("2.9.0")).availableUpdate("3.0.0"))
+        assertEquals(null, UiState.Loading.availableUpdate("3.0.0"))
+        assertEquals(null, UiState.Error(IllegalStateException()).availableUpdate("3.0.0"))
+    }
+
+    @Test
+    fun `debug override makes every update state deterministically testable`() {
+        val original = UiState.Error(IllegalStateException("offline"))
+
+        assertEquals(original, original.withDebugUpdateOverride(enabled = false))
+        val overridden = original.withDebugUpdateOverride(enabled = true)
+        val info = (overridden as UiState.Success).data
+        assertEquals(info, overridden.availableUpdate("3.0.0"))
+        assertTrue(info.downloads.isEmpty())
+    }
+
+    private fun updateInfo(version: String) = UpdateInfo(
+        version = version,
+        publishedAt = "2026-08-26T00:00:00Z",
+        changelog = "Changes",
+        downloads = emptyList(),
+        releaseUrl = "https://example.com/releases/$version",
+    )
 }

--- a/docs/miffan/ACCEPTANCE.md
+++ b/docs/miffan/ACCEPTANCE.md
@@ -24,6 +24,8 @@
 - Theme-synced colors update for dynamic, preset, and custom themes in both light and dark mode.
 - Theme sync changes colors without changing kind, material, contents, accessories, or motion profile.
 - Thinking, happy, error, idle, focused, and typing states work for every palette.
+- Update-available state remains readable for every character and palette at avatar sizes.
+- An idle Miffan on the empty chat page receives the update-available semantic state; chat errors still take priority.
 - Decorative input cues use palette-derived colors rather than Classic-only hard-coded colors.
 - No palette changes geometry or interaction hit targets.
 - Lively, Calm, and Curious share the same semantic states without duplicated drawing implementations.
@@ -49,6 +51,7 @@
 
 ## Regression and delivery
 
+- In a Debug build, Settings > About > long-press Version opens Debug Mode, where the update-reminder preview can deterministically drive the drawer badge, Settings banner, and Miffan update-available state without a real release.
 - Avatar serialization round-trips for all Miffan presets.
 - Avatar serialization round-trips for every palette and motion-profile combination.
 - Avatar serialization round-trips for every character-kind, palette, and motion-profile combination.

--- a/docs/miffan/PRODUCT.md
+++ b/docs/miffan/PRODUCT.md
@@ -77,6 +77,7 @@ Components ask Miffan to express meaning rather than selecting animation clips. 
 - Thinking
 - Happy
 - Error
+- Update available
 - input focused
 - typing
 - submitted


### PR DESCRIPTION
## Summary\n\n- replace the large drawer update card with a restrained badge on Settings\n- add a compact update banner at the top of Settings while reusing the existing update flow\n- propagate update availability as semantic state to Miffan avatars and the empty-chat mascot\n- add a Debug-only deterministic update preview and regression tests\n\n## Verification\n\n- focused JVM unit tests\n- :app:compileDebugKotlin\n- assembleDebug\n- universal and arm64 APK signature verification