### PR TITLE
ci: streamline verified release pipeline

### DIFF
--- a/.github/scripts/verify_release_pr.sh
+++ b/.github/scripts/verify_release_pr.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+expected_commit="${EXPECTED_COMMIT:?EXPECTED_COMMIT is required}"
+expected_commit="$(printf '%s' "$expected_commit" | tr '[:upper:]' '[:lower:]')"
+
+pulls_json="$(
+  gh api \
+    --header "Accept: application/vnd.github+json" \
+    "repos/$repository/commits/$expected_commit/pulls"
+)"
+source_pr_json="$(
+  jq -c \
+    --arg commit "$expected_commit" \
+    '[
+      .[]
+      | select(
+          .merged_at != null
+          and ((.merge_commit_sha // "") | ascii_downcase) == $commit
+          and .base.ref == "master"
+        )
+    ]
+    | if length == 1 then .[0] else empty end' \
+    <<< "$pulls_json"
+)"
+
+if [ -z "$source_pr_json" ]; then
+  echo "Release target must be the merge commit of exactly one merged PR into master" >&2
+  exit 1
+fi
+
+source_pr_number="$(jq -r '.number' <<< "$source_pr_json")"
+source_head_sha="$(jq -r '.head.sha' <<< "$source_pr_json")"
+source_head_ref="$(jq -r '.head.ref' <<< "$source_pr_json")"
+
+ci_runs_json="$(
+  gh api \
+    --method GET \
+    "repos/$repository/actions/runs" \
+    -f head_sha="$source_head_sha" \
+    -f event="pull_request" \
+    -f status="success" \
+    -F per_page=100
+)"
+
+if ! jq -e \
+  --arg head_sha "$source_head_sha" \
+  --arg head_ref "$source_head_ref" \
+  'any(
+    .workflow_runs[];
+    .path == ".github/workflows/ci.yml"
+      and .event == "pull_request"
+      and .head_sha == $head_sha
+      and .head_branch == $head_ref
+      and .conclusion == "success"
+  )' \
+  >/dev/null \
+  <<< "$ci_runs_json"; then
+  echo "PR #$source_pr_number has no successful pull-request CI run for $source_head_sha" >&2
+  exit 1
+fi
+
+echo "Verified release target from PR #$source_pr_number with successful pull-request CI"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,11 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: write
   id-token: write
   attestations: write
+  pull-requests: read
 
 concurrency:
   group: production-release-${{ inputs.release_version }}
@@ -64,6 +66,7 @@ jobs:
             echo "Requested commit must be reachable from origin/master" >&2
             exit 1
           fi
+          bash .github/scripts/verify_release_pr.sh
 
           semver_regex='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
           if [[ ! "$EXPECTED_VERSION" =~ $semver_regex ]]; then
@@ -197,8 +200,10 @@ jobs:
             exit 1
           fi
 
-      - name: Build production release from requested commit
-        run: ./gradlew test lint assembleRelease --stacktrace
+      - name: Build production release from verified commit
+        # Tests and lint already passed on the source PR. This step keeps the
+        # release-only optimization, packaging, and signing work.
+        run: ./gradlew assembleRelease --stacktrace
 
       - name: Verify package, version, ABI, and production signature
         id: stage

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -95,7 +95,7 @@ When these four entries are absent, `assembleRelease` may produce unsigned verif
 2. Select and record the exact target commit. Do not silently build a moving branch head.
 3. Set an independent SemVer `versionName` and a strictly increasing `versionCode` in `app/build.gradle.kts`.
 4. Add bilingual notes at `docs/releases/<version>.md` using [the template](releases/TEMPLATE.md). Keep Miffan-owned changes separate from improvements incorporated from RikkaHub.
-5. Require the PR/push CI workflow to pass `test`, `lint`, and `assembleDebug` before merging the target commit.
+5. Require the pull-request CI workflow to pass `test`, `lint`, and `assembleDebug` before merging the target commit. CI does not repeat the same full verification after the protected PR is merged to `master`; it can still be started manually when needed.
 6. Review the in-place upgrade acceptance below for any release that shares the official package name.
 
 No upstream tag is a Miffan release trigger. Do not fetch-and-push, mirror, or automatically propagate upstream tags.
@@ -108,13 +108,15 @@ Run `.github/workflows/release.yml` manually and provide all three explicit inpu
 - the exact SemVer `versionName`;
 - the exact Android `versionCode`.
 
-The workflow is gated by the `production` Environment. It verifies that the requested commit, source version, and notes agree; refuses to replace an existing tag; runs tests and lint; builds the release; and checks:
+The workflow is gated by the `production` Environment. It verifies that the requested commit is the merge commit of a PR into `master`, and that the source PR head has a successful run of `.github/workflows/ci.yml`. It also verifies that the source version and notes agree, refuses to replace an existing tag, builds the production release without repeating the PR's full tests and debug lint, and checks:
 
 - application ID is `me.ayuilos.miffan.app`;
 - `versionName` and `versionCode` match the approved inputs;
 - the staged APK is arm64-only;
 - the signer SHA-256 matches the Miffan production trust anchor;
 - the asset name follows the official convention.
+
+`assembleRelease` still performs R8 optimization, packaging, and signing. Lint remains a required pull-request check, and the workflow never skips the artifact, signer, ABI, checksum, or provenance checks.
 
 It then computes SHA-256, creates GitHub build provenance for the verified APK with `actions/attest@v4`, uploads the verified APK/checksum as a workflow artifact, and prepares a draft GitHub Release at the requested commit. A version containing a prerelease component is marked as a prerelease. The workflow does not make the draft public; publication remains a separate approval.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@ org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
## Summary
- run the full test, lint, and debug build gate once per pull request instead of repeating it after every merge
- require production releases to prove their target is a merged master PR whose exact head passed CI
- keep production-only optimization, signing, APK validation, checksum, and provenance while removing duplicate test/lint work
- enable Gradle parallel execution and task output caching
- document the optimized safety model

## Validation
- ./gradlew test lint assembleDebug --stacktrace
- positive release-gate check against the 3.0.1 merge commit
- negative release-gate check against the unmerged PR head commit
- Bash syntax, YAML parsing, and git diff checks