### PR TITLE
release: prepare Miffan 3.0.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to RikkaHub
+
+Thank you for your interest in contributing to RikkaHub. To keep reviews focused and the project
+maintainable, please read the following rules before opening a pull request.
+
+## Contribution policy
+
+### Every pull request must be linked to an issue
+
+Open an issue before starting work. Every pull request must reference at least one related issue in
+its description, for example with `Fixes #123` or `Related to #123`.
+
+Pull requests without a corresponding issue will not be accepted.
+
+### No new-feature pull requests
+
+We do not accept pull requests that add new features. RikkaHub is an opinionated project, and new
+features need to be designed and implemented by the maintainers to keep the product direction and
+user experience consistent.
+
+You may still submit a feature request as an issue for discussion, but please do not send an
+implementation pull request.
+
+### No large pull requests
+
+We do not accept large pull requests, including broad refactors, sweeping architectural changes, or
+changes that combine several unrelated concerns. Keep each pull request small, focused, and easy to
+review.
+
+If a fix requires extensive changes, discuss it in the related issue first. The maintainers may ask
+you to reduce the scope or split the work into multiple independent pull requests.
+
+## What we accept
+
+In general, acceptable contributions include:
+
+- Small, focused bug fixes for an existing issue
+- Small documentation corrections
+- Small maintenance changes that preserve existing behavior
+
+Translation-related pull requests are not accepted.
+
+## Before submitting
+
+Please make sure that your pull request:
+
+- Links to at least one issue
+- Contains one focused change and is not a large-scale modification
+- Does not add a new feature
+- Explains what changed and how it was verified
+- Follows the existing code style
+- Builds successfully and does not introduce unrelated changes
+
+Pull requests that do not follow these guidelines may be closed without review.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Click to join our Discord server 👉 [【RikkaHub】](https://discord.gg/9weBqx
 
 ## ✨ Contributing
 
-This project is developed using [Android Studio](https://developer.android.com/studio). PRs are
-welcome!
+This project is developed using [Android Studio](https://developer.android.com/studio). Before
+submitting a pull request, please read the [contribution guidelines](CONTRIBUTING.md).
 
 Technology stack documentation:
 

--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -344,6 +344,12 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
+    private val QWEN_3_8 = defineModel {
+        tokens("qwen", "3", "8")
+        visionInput()
+        toolReasoningAbility()
+    }
+
     private val QWEN_3_5_MAX = defineModel {
         tokens("qwen", "3", "5", "max")
         toolReasoningAbility()
@@ -603,6 +609,7 @@ object ModelRegistry {
         QWEN_3_5,
         QWEN_3_6,
         QWEN_3_7,
+        QWEN_3_8,
         QWEN_3_5_MAX,
         QWEN_3_6_MAX,
         QWEN_3_7_MAX,

--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -537,6 +537,12 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
+    private val HY4 = defineModel {
+        tokens("hy", "4")
+        visionInput()
+        toolReasoningAbility()
+    }
+
     private val LONGCAT_2 = defineModel {
         tokens("longcat", "2", "0")
         toolReasoningAbility()
@@ -644,6 +650,7 @@ object ModelRegistry {
         XIAOMI_MIMO_V3,
         XIAOMI_MIMO_V3_PRO,
         HY3,
+        HY4,
         LONGCAT_2,
         MUSE_SPARK,
         MUSE_GLIMMER,

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.util.json
@@ -23,7 +24,10 @@ data class UIMessage(
     val finishedAt: LocalDateTime? = null,
     val modelId: Uuid? = null,
     val usage: TokenUsage? = null,
-    val translation: String? = null
+    val translation: String? = null,
+    // 请求期间生成的内部消息；该标记仅在内存中使用
+    @Transient
+    val isSynthetic: Boolean = false,
 ) {
     fun summaryAsText(maxLength: Int = Int.MAX_VALUE): String {
         val text = "[${role.name}]: " + parts.joinToString(separator = "\n") { part ->

--- a/ai/src/test/java/me/rerere/ai/ui/UIMessageSerializationTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/UIMessageSerializationTest.kt
@@ -1,0 +1,21 @@
+package me.rerere.ai.ui
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UIMessageSerializationTest {
+
+    @Test
+    fun `synthetic marker is not serialized`() {
+        val message = UIMessage.user("internal").copy(isSynthetic = true)
+
+        val encoded = Json.encodeToString(message)
+        val decoded = Json.decodeFromString<UIMessage>(encoded)
+
+        assertTrue(message.isSynthetic)
+        assertFalse(encoded.contains("isSynthetic"))
+        assertFalse(decoded.isSynthetic)
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "me.ayuilos.miffan.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 178005
-        versionName = "3.0.2"
+        versionCode = 178006
+        versionName = "3.0.3"
 
         buildConfigField("boolean", "FIREBASE_ENABLED", hasGoogleServicesConfig.toString())
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
   <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
   <uses-permission
@@ -128,6 +129,10 @@
       android:name="com.yalantis.ucrop.UCropActivity"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
+    <service
+      android:name=".service.ChatGenerationForegroundService"
+      android:exported="false"
+      android:foregroundServiceType="dataSync" />
     <service
       android:name=".service.WebServerService"
       android:exported="false"

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/chat/ChatPage.kt
@@ -6,8 +6,13 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
@@ -68,14 +73,18 @@ import me.rerere.ai.ui.UIMessagePart
 import me.rerere.common.android.appTempFolder
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Cancel01
+import me.rerere.hugeicons.stroke.FolderOpen
+import me.rerere.hugeicons.stroke.FolderUnknown
 import me.rerere.hugeicons.stroke.LeftToRightListBullet
 import me.rerere.hugeicons.stroke.Menu03
 import me.rerere.hugeicons.stroke.MessageAdd01
 import me.ayuilos.miffan.R
+import me.ayuilos.miffan.Screen
 import me.ayuilos.miffan.data.datastore.Settings
 import me.ayuilos.miffan.data.datastore.findProvider
 import me.ayuilos.miffan.data.datastore.getCurrentAssistant
 import me.ayuilos.miffan.data.datastore.getCurrentChatModel
+import me.ayuilos.miffan.data.db.entity.WorkspaceEntity
 import me.ayuilos.miffan.data.files.FilesManager
 import me.ayuilos.miffan.data.model.Assistant
 import me.ayuilos.miffan.data.model.Conversation
@@ -103,6 +112,8 @@ import me.ayuilos.miffan.utils.ImageUtils
 import me.ayuilos.miffan.utils.base64Decode
 import me.ayuilos.miffan.utils.isAllowedFileType
 import me.ayuilos.miffan.utils.navigateToChatPage
+import me.rerere.workspace.WorkspaceShellStatus
+import me.rerere.workspace.WorkspaceStorageArea
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
@@ -281,6 +292,59 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
     }
 }
 
+internal data class ChatWorkspaceEntry(
+    val id: String,
+    val name: String?,
+    val warning: Boolean,
+)
+
+internal fun resolveChatWorkspaceEntry(
+    boundWorkspaceId: String?,
+    workspace: WorkspaceEntity?,
+): ChatWorkspaceEntry? {
+    val id = boundWorkspaceId ?: return null
+    val matchingWorkspace = workspace?.takeIf { it.id == id }
+    val shellStatus = matchingWorkspace?.shellStatus?.let { status ->
+        runCatching { WorkspaceShellStatus.valueOf(status) }.getOrNull()
+    }
+    return ChatWorkspaceEntry(
+        id = id,
+        name = matchingWorkspace?.name?.takeIf { it.isNotBlank() },
+        warning = matchingWorkspace == null ||
+            shellStatus == null ||
+            shellStatus == WorkspaceShellStatus.BROKEN,
+    )
+}
+
+internal fun workspaceCwdToFilesPath(workspaceCwd: String?): String {
+    val normalized = workspaceCwd
+        ?.replace('\\', '/')
+        ?.trim()
+        ?.trimEnd('/')
+        .orEmpty()
+    if (normalized.isBlank()) return ""
+
+    val relativePath = when {
+        normalized == "/workspace" || normalized == "workspace" -> ""
+        normalized.startsWith("/workspace/") -> normalized.removePrefix("/workspace/")
+        normalized.startsWith("workspace/") -> normalized.removePrefix("workspace/")
+        normalized.startsWith('/') -> return ""
+        else -> normalized
+    }
+    val segments = relativePath.split('/').filter { it.isNotBlank() && it != "." }
+    if (segments.any { it == ".." }) return ""
+    return segments.joinToString("/")
+}
+
+internal fun workspaceFilesRoute(workspaceId: String, workspaceCwd: String?): Screen.WorkspaceDetail {
+    return Screen.WorkspaceDetail(
+        id = workspaceId,
+        area = WorkspaceStorageArea.FILES.name,
+        path = workspaceCwdToFilesPath(workspaceCwd),
+        openFiles = true,
+    )
+}
+
 @Composable
 private fun ChatPageContent(
     inputState: ChatInputState,
@@ -307,6 +371,12 @@ private fun ChatPageContent(
     var previewMode by rememberSaveable { mutableStateOf(false) }
     val hazeState = rememberHazeState()
     val assistant = setting.getCurrentAssistant()
+    val workspaceId = assistant.workspaceId?.toString()
+    val workspaces by workspaceRepository.listFlow().collectAsStateWithLifecycle(initialValue = emptyList())
+    val workspaceEntry = resolveChatWorkspaceEntry(
+        boundWorkspaceId = workspaceId,
+        workspace = workspaces.find { it.id == workspaceId },
+    )
     var showFilesSheet by remember { mutableStateOf(false) }
     var mascotInputState by remember(conversation.id) {
         mutableStateOf(MiffanMascotInputState.Inactive)
@@ -340,8 +410,12 @@ private fun ChatPageContent(
                     bigScreen = bigScreen,
                     drawerState = drawerState,
                     previewMode = previewMode,
+                    workspaceEntry = workspaceEntry,
                     onNewChat = {
                         navigateToChatPage(navController)
+                    },
+                    onOpenWorkspace = { entry ->
+                        navController.navigate(workspaceFilesRoute(entry.id, conversation.workspaceCwd))
                     },
                     onClickMenu = {
                         previewMode = !previewMode
@@ -775,14 +849,78 @@ private fun ChatFilesPickerSheet(
 }
 
 @Composable
+private fun WorkspaceTopBarAction(
+    entry: ChatWorkspaceEntry,
+    showName: Boolean,
+    onClick: () -> Unit,
+) {
+    val workspaceLabel = stringResource(R.string.extensions_page_workspace)
+    val filesLabel = stringResource(R.string.workspace_detail_tab_files)
+    val errorLabel = stringResource(R.string.workspace_detail_shell_broken)
+    val displayName = entry.name ?: workspaceLabel
+    val actionLabel = buildString {
+        append(workspaceLabel)
+        append(' ')
+        append(filesLabel)
+        if (!showName) {
+            append(": ")
+            append(displayName)
+        }
+        if (entry.warning) {
+            append(", ")
+            append(errorLabel)
+        }
+    }
+    val contentColor = if (entry.warning) {
+        MaterialTheme.colorScheme.error
+    } else {
+        LocalContentColor.current
+    }
+    val icon = if (entry.warning) HugeIcons.FolderUnknown else HugeIcons.FolderOpen
+
+    if (showName) {
+        TextButton(
+            onClick = onClick,
+            modifier = Modifier
+                .heightIn(min = 48.dp)
+                .widthIn(max = 200.dp),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = actionLabel,
+                modifier = Modifier.size(20.dp),
+                tint = contentColor,
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = displayName,
+                color = contentColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    } else {
+        IconButton(onClick = onClick) {
+            Icon(
+                imageVector = icon,
+                contentDescription = actionLabel,
+                tint = contentColor,
+            )
+        }
+    }
+}
+
+@Composable
 private fun TopBar(
     settings: Settings,
     conversation: Conversation,
     drawerState: DrawerState,
     bigScreen: Boolean,
     previewMode: Boolean,
+    workspaceEntry: ChatWorkspaceEntry?,
     onClickMenu: () -> Unit,
     onNewChat: () -> Unit,
+    onOpenWorkspace: (ChatWorkspaceEntry) -> Unit,
     onUpdateTitle: (String) -> Unit
 ) {
     val scope = rememberCoroutineScope()
@@ -841,6 +979,14 @@ private fun TopBar(
             }
         },
         actions = {
+            workspaceEntry?.let { entry ->
+                WorkspaceTopBarAction(
+                    entry = entry,
+                    showName = bigScreen,
+                    onClick = { onOpenWorkspace(entry) },
+                )
+            }
+
             IconButton(
                 onClick = {
                     onClickMenu()

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -387,7 +387,9 @@ class GenerationHandler(
                     append(tool.systemPrompt(model, messages))
                 }
             }
-            if (system.isNotBlank()) add(UIMessage.system(prompt = system))
+            if (system.isNotBlank()) {
+                add(UIMessage.system(prompt = system).copy(isSynthetic = true))
+            }
             addAll(messages.limitContext(assistant.contextMessageLimit))
         }.transforms(
             transformers = transformers,

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
@@ -31,11 +34,11 @@ import me.rerere.ai.ui.ToolApprovalState
 import me.rerere.ai.ui.StreamChunkHandler
 import me.rerere.ai.ui.handleTextGenerationResult
 import me.rerere.ai.ui.limitContext
+import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.ai.transformers.InputMessageTransformer
 import me.rerere.rikkahub.data.ai.transformers.MessageTransformer
 import me.rerere.rikkahub.data.ai.transformers.OutputMessageTransformer
 import me.rerere.rikkahub.data.files.FileFolders
-import java.io.File
 import me.rerere.rikkahub.data.ai.transformers.onGenerationFinish
 import me.rerere.rikkahub.data.ai.transformers.transforms
 import me.rerere.rikkahub.data.ai.transformers.visualTransforms
@@ -47,6 +50,12 @@ import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.AssistantMemory
 import me.rerere.rikkahub.data.repository.MemoryRepository
 import me.rerere.rikkahub.utils.applyPlaceholders
+import java.io.File
+import java.io.IOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.util.Locale
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
@@ -54,6 +63,10 @@ import kotlin.uuid.Uuid
 private const val TAG = "GenerationHandler"
 private const val MAX_TOOL_OUTPUT_CHARS = 32 * 1024
 private const val TOOL_OUTPUT_PREVIEW_CHARS = 4 * 1024
+private const val MAX_PROVIDER_NETWORK_RETRIES = 3
+private const val INITIAL_PROVIDER_RETRY_DELAY_MS = 1_000L
+
+private class StreamChunkHandlingException(cause: Throwable) : RuntimeException(cause)
 
 @Serializable
 sealed interface GenerationChunk {
@@ -421,25 +434,130 @@ class GenerationHandler(
             },
             sessionId = conversationId?.toString(),
         )
-        if (stream) {
-            val streamChunkHandler = StreamChunkHandler(model)
-            providerImpl.streamText(
-                providerSetting = provider,
-                messages = internalMessages,
-                params = params
-            ).collect {
-                messages = streamChunkHandler.handle(messages, it)
+        try {
+            if (stream) {
+                // 每次重试都从本次模型调用开始前的消息快照重新合并，避免将重试响应
+                // 追加到已经展示的半截回复后面。预先创建助手消息可让所有尝试复用同一 ID，
+                // ChatService 因而会覆盖当前分支，而不是创建新的候选消息。
+                val responseBaseMessages =
+                    if (messages.lastOrNull()?.role == MessageRole.ASSISTANT) {
+                        messages
+                    } else {
+                        messages + UIMessage(
+                            role = MessageRole.ASSISTANT,
+                            parts = emptyList(),
+                            modelId = model.id,
+                        )
+                    }
+                var retryCount = 0
+
+                while (true) {
+                    val streamChunkHandler = StreamChunkHandler(model)
+                    var attemptMessages = responseBaseMessages
+                    try {
+                        providerImpl.streamText(
+                            providerSetting = provider,
+                            messages = internalMessages,
+                            params = params
+                        ).collect { chunk ->
+                            try {
+                                if (retryCount > 0) {
+                                    processingStatus.value = null
+                                }
+                                attemptMessages = streamChunkHandler.handle(attemptMessages, chunk)
+                                onUpdateMessages(attemptMessages)
+                            } catch (error: CancellationException) {
+                                throw error
+                            } catch (error: Throwable) {
+                                // 下游消息转换或 UI 更新失败不属于网络故障，不能重放模型请求。
+                                throw StreamChunkHandlingException(error)
+                            }
+                        }
+                        messages = attemptMessages
+                        break
+                    } catch (error: Throwable) {
+                        if (error is StreamChunkHandlingException) {
+                            throw error.cause ?: error
+                        }
+                        retryCount = awaitNetworkRetryOrThrow(
+                            error = error,
+                            retryCount = retryCount,
+                            processingStatus = processingStatus,
+                        )
+                    }
+                }
+            } else {
+                val result = executeProviderRequestWithRetry(processingStatus) {
+                    providerImpl.generateText(
+                        providerSetting = provider,
+                        messages = internalMessages,
+                        params = params,
+                    )
+                }
+                messages = messages.handleTextGenerationResult(result = result, model = model)
                 onUpdateMessages(messages)
             }
-        } else {
-            val result = providerImpl.generateText(
-                providerSetting = provider,
-                messages = internalMessages,
-                params = params,
-            )
-            messages = messages.handleTextGenerationResult(result = result, model = model)
-            onUpdateMessages(messages)
+        } finally {
+            processingStatus.value = null
         }
+    }
+
+    private suspend fun <T> executeProviderRequestWithRetry(
+        processingStatus: MutableStateFlow<String?>,
+        block: suspend () -> T,
+    ): T {
+        var retryCount = 0
+        while (true) {
+            try {
+                return block()
+            } catch (error: Throwable) {
+                retryCount = awaitNetworkRetryOrThrow(
+                    error = error,
+                    retryCount = retryCount,
+                    processingStatus = processingStatus,
+                )
+            }
+        }
+    }
+
+    private suspend fun awaitNetworkRetryOrThrow(
+        error: Throwable,
+        retryCount: Int,
+        processingStatus: MutableStateFlow<String?>,
+    ): Int {
+        // 用户主动停止生成时，底层连接也可能以 IOException("canceled") 收尾；
+        // 先检查协程状态，确保取消不会被当作网络波动重新拉起。
+        currentCoroutineContext().ensureActive()
+        if (error !is IOException || retryCount >= MAX_PROVIDER_NETWORK_RETRIES) {
+            throw error
+        }
+
+        val nextRetryCount = retryCount + 1
+        val retryDelay = INITIAL_PROVIDER_RETRY_DELAY_MS shl retryCount
+        processingStatus.value = context.getString(
+            R.string.chat_generation_network_retrying,
+            getNetworkErrorMessage(error),
+            nextRetryCount,
+            MAX_PROVIDER_NETWORK_RETRIES,
+        )
+        Log.w(
+            TAG,
+            "Provider connection failed, retrying in ${retryDelay}ms " +
+                    "($nextRetryCount/$MAX_PROVIDER_NETWORK_RETRIES)",
+            error,
+        )
+        delay(retryDelay)
+        return nextRetryCount
+    }
+
+    private fun getNetworkErrorMessage(error: IOException): String {
+        val messageRes = when (error) {
+            is UnknownHostException -> R.string.chat_generation_network_unknown_host
+            is SocketTimeoutException -> R.string.chat_generation_network_timeout
+            is ConnectException, is NoRouteToHostException -> R.string.chat_generation_network_unreachable
+            else -> R.string.chat_generation_network_disconnected
+        }
+        return context.getString(messageRes)
     }
 
     private fun maybeTruncateToolOutput(

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
@@ -153,7 +153,8 @@ internal fun applyInjections(
             }
 
             result[systemIndex] = systemMessage.copy(
-                parts = listOf(UIMessagePart.Text(newText))
+                parts = listOf(UIMessagePart.Text(newText)),
+                isSynthetic = true,
             )
         }
     } else {
@@ -174,7 +175,7 @@ internal fun applyInjections(
         }
 
         if (combinedContent.isNotEmpty()) {
-            result.add(0, UIMessage.system(combinedContent))
+            result.add(0, UIMessage.system(combinedContent).copy(isSynthetic = true))
         }
     }
 
@@ -235,7 +236,9 @@ private fun createMergedInjectionMessages(injections: List<PromptInjection>): Li
             when (role) {
                 MessageRole.ASSISTANT -> UIMessage.assistant(mergedContent)
                 else -> UIMessage.user(mergedContent)
-            }
+            }.copy(
+                isSynthetic = true,
+            )
         }
 }
 

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TemplateTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TemplateTransformer.kt
@@ -25,6 +25,8 @@ class TemplateTransformer(
         val template = engine.getTemplate(ctx.assistant.id.toString())
         val timeZone = TimeZone.currentSystemDefault()
         return messages.map { message ->
+            if (message.isSynthetic) return@map message
+
             // 使用消息本身的发送时间而不是当前时间, 保证多次请求时渲染结果稳定, 不破坏 prompt 缓存
             val createdAt = message.createdAt.toInstant(timeZone).toJavaInstant()
             message.copy(

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformer.kt
@@ -67,7 +67,7 @@ private fun buildTimeReminderMessage(gapSeconds: Long?, instant: Instant): UIMes
     } else {
         "<time_reminder>Current time: $dayOfWeek, $timeStr</time_reminder>"
     }
-    return UIMessage.user(content)
+    return UIMessage.user(content).copy(isSynthetic = true)
 }
 
 private fun formatGap(seconds: Long): String {

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/WorkspaceReminderTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/WorkspaceReminderTransformer.kt
@@ -31,10 +31,12 @@ class WorkspaceReminderTransformer(
         val systemIndex = messages.indexOfFirst { it.role == MessageRole.SYSTEM }
         return if (systemIndex >= 0) {
             messages.toMutableList().apply {
-                this[systemIndex] = this[systemIndex].appendText("\n\n$prompt")
+                this[systemIndex] = this[systemIndex]
+                    .appendText("\n\n$prompt")
+                    .copy(isSynthetic = true)
             }
         } else {
-            listOf(UIMessage.system(prompt)) + messages
+            listOf(UIMessage.system(prompt).copy(isSynthetic = true)) + messages
         }
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatGenerationForegroundService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatGenerationForegroundService.kt
@@ -1,0 +1,173 @@
+package me.rerere.rikkahub.service
+
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.launch
+import me.rerere.rikkahub.AppScope
+import me.rerere.rikkahub.CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.RouteActivity
+import org.koin.android.ext.android.inject
+import kotlin.uuid.Uuid
+
+private const val TAG = "ChatGenerationFgs"
+
+/**
+ * Keeps the app process in the foreground while one or more chat generations are active.
+ *
+ * Generation itself remains owned by [ChatService]. This service only provides the Android
+ * foreground-service lifetime required for streaming to continue after the activity is hidden.
+ */
+class ChatGenerationForegroundService : Service() {
+    companion object {
+        private const val ACTION_ACQUIRE = "me.rerere.rikkahub.action.CHAT_GENERATION_ACQUIRE"
+        private const val ACTION_RELEASE = "me.rerere.rikkahub.action.CHAT_GENERATION_RELEASE"
+        private const val EXTRA_GENERATION_ID = "generation_id"
+        private const val EXTRA_CONVERSATION_ID = "conversation_id"
+
+        const val NOTIFICATION_ID = 2002
+
+        fun acquire(context: Context, generationId: Uuid, conversationId: Uuid): Boolean {
+            val intent = Intent(context, ChatGenerationForegroundService::class.java).apply {
+                action = ACTION_ACQUIRE
+                putExtra(EXTRA_GENERATION_ID, generationId.toString())
+                putExtra(EXTRA_CONVERSATION_ID, conversationId.toString())
+            }
+            return runCatching {
+                ContextCompat.startForegroundService(context, intent)
+                true
+            }.onFailure {
+                Log.e(TAG, "Unable to start chat generation foreground service", it)
+            }.getOrDefault(false)
+        }
+
+        fun release(context: Context, generationId: Uuid) {
+            val intent = Intent(context, ChatGenerationForegroundService::class.java).apply {
+                action = ACTION_RELEASE
+                putExtra(EXTRA_GENERATION_ID, generationId.toString())
+            }
+            runCatching {
+                context.startService(intent)
+            }.onFailure {
+                Log.e(TAG, "Unable to release chat generation foreground service", it)
+            }
+        }
+    }
+
+    private val activeGenerations = linkedMapOf<String, String>()
+    private var isForeground = false
+    private val appScope: AppScope by inject()
+    private val chatService: ChatService by inject()
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_ACQUIRE -> acquire(intent)
+            ACTION_RELEASE -> release(intent)
+            else -> stopService()
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        activeGenerations.clear()
+        if (isForeground) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            isForeground = false
+        }
+        super.onDestroy()
+    }
+
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        Log.e(TAG, "Foreground service timed out (type=$fgsType)")
+        activeGenerations.values
+            .mapNotNull { runCatching { Uuid.parse(it) }.getOrNull() }
+            .distinct()
+            .forEach { conversationId ->
+                appScope.launch {
+                    chatService.stopGeneration(conversationId)
+                }
+            }
+        // Android only allows a few seconds after onTimeout before raising RemoteServiceException.
+        stopService()
+    }
+
+    private fun acquire(intent: Intent) {
+        val generationId = intent.getStringExtra(EXTRA_GENERATION_ID) ?: return stopService()
+        val conversationId = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: return stopService()
+        activeGenerations[generationId] = conversationId
+        updateForegroundNotification(conversationId)
+    }
+
+    private fun release(intent: Intent) {
+        intent.getStringExtra(EXTRA_GENERATION_ID)?.let(activeGenerations::remove)
+        if (activeGenerations.isEmpty()) {
+            stopService()
+        } else {
+            updateForegroundNotification(activeGenerations.values.last())
+        }
+    }
+
+    private fun updateForegroundNotification(conversationId: String) {
+        try {
+            val notification = buildNotification(conversationId)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceCompat.startForeground(
+                    this,
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+            isForeground = true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to enter foreground", e)
+            activeGenerations.clear()
+            stopSelf()
+        }
+    }
+
+    private fun stopService() {
+        if (isForeground) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            isForeground = false
+        }
+        stopSelf()
+    }
+
+    private fun buildNotification(conversationId: String) =
+        NotificationCompat.Builder(this, CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_stat_rikkahub)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.notification_live_update_title))
+            .setContentIntent(getConversationPendingIntent(conversationId))
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .build()
+
+    private fun getConversationPendingIntent(conversationId: String): PendingIntent {
+        val intent = Intent(this, RouteActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra("conversationId", conversationId)
+        }
+        return PendingIntent.getActivity(
+            this,
+            NOTIFICATION_ID,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatNotificationManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatNotificationManager.kt
@@ -109,10 +109,6 @@ class ChatNotificationManager(
         }
     }
 
-    private fun getLiveUpdateNotificationId(conversationId: Uuid): Int {
-        return conversationId.hashCode() + 10000
-    }
-
     private fun sendLiveUpdateNotification(
         conversationId: Uuid,
         lastMessage: UIMessage,
@@ -123,7 +119,8 @@ class ChatNotificationManager(
 
         context.sendNotification(
             channelId = CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID,
-            notificationId = getLiveUpdateNotificationId(conversationId)
+            // 更新前台服务正在使用的同一条通知，避免重复显示生成进度。
+            notificationId = ChatGenerationForegroundService.NOTIFICATION_ID
         ) {
             title = senderName
             content = contentText
@@ -183,7 +180,8 @@ class ChatNotificationManager(
 
     private fun cancelLiveUpdateNotification(conversationId: Uuid) {
         liveUpdateLastSentAt.remove(conversationId)
-        context.cancelNotification(getLiveUpdateNotificationId(conversationId))
+        // 前台服务持有通知时系统会保留它；启动失败时则清理普通 ongoing 通知。
+        context.cancelNotification(ChatGenerationForegroundService.NOTIFICATION_ID)
     }
 
     private fun getPendingIntent(context: Context, conversationId: Uuid): PendingIntent {

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -296,6 +296,30 @@ class ChatService(
         }
     }
 
+    private fun launchGenerationJob(
+        conversationId: Uuid,
+        keepAliveInBackground: Boolean = true,
+        block: suspend () -> Unit,
+    ): Job {
+        if (!keepAliveInBackground) return appScope.launch { block() }
+
+        val generationId = Uuid.random()
+        val foregroundStarted = ChatGenerationForegroundService.acquire(
+            context = context,
+            generationId = generationId,
+            conversationId = conversationId,
+        )
+        return appScope.launch {
+            try {
+                block()
+            } finally {
+                if (foregroundStarted) {
+                    ChatGenerationForegroundService.release(context, generationId)
+                }
+            }
+        }
+    }
+
     // ---- 初始化对话 ----
 
     suspend fun initializeConversation(conversationId: Uuid) {
@@ -326,7 +350,10 @@ class ChatService(
         val previousJob = session.getJob()
         previousJob?.cancel()
 
-        val job = appScope.launch {
+        val job = launchGenerationJob(
+            conversationId = conversationId,
+            keepAliveInBackground = answer,
+        ) {
             try {
                 runCatching { previousJob?.join() }
                 finishInterruptedPendingTools(conversationId)
@@ -388,7 +415,10 @@ class ChatService(
         val session = getOrCreateSession(conversationId)
         session.getJob()?.cancel()
 
-        val job = appScope.launch {
+        val job = launchGenerationJob(
+            conversationId = conversationId,
+            keepAliveInBackground = message.role == MessageRole.USER || regenerateAssistantMsg,
+        ) {
             try {
                 val conversation = session.state.value
 
@@ -432,7 +462,16 @@ class ChatService(
         val session = getOrCreateSession(conversationId)
         session.getJob()?.cancel()
 
-        val job = appScope.launch {
+        val hasOtherPendingTools = session.state.value.messageNodes.any { node ->
+            node.currentMessage.parts.any { part ->
+                part is UIMessagePart.Tool && part.isPending && part.toolCallId != toolCallId
+            }
+        }
+
+        val job = launchGenerationJob(
+            conversationId = conversationId,
+            keepAliveInBackground = !hasOtherPendingTools,
+        ) {
             try {
                 val conversation = session.state.value
                 val newApprovalState = when {

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -277,8 +277,7 @@ class ChatService(
     }
 
     fun getProcessingStatusFlow(conversationId: Uuid): StateFlow<String?> {
-        val session = sessions[conversationId] ?: return MutableStateFlow(null)
-        return session.processingStatus
+        return getOrCreateSession(conversationId).processingStatus
     }
 
     fun getConversationJobs(): Flow<Map<Uuid, Job?>> {

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -150,6 +150,11 @@ fun ChatInput(
     val density = LocalDensity.current
     // Unlike isImeVisible, the target changes as soon as the IME animation starts.
     val imeTargetVisible = WindowInsets.imeAnimationTarget.getBottom(density) > 0
+    val modelListState = rememberModelListState(
+        modelId = assistant.chatModelId ?: settings.chatModelId,
+        providers = settings.providers,
+        type = ModelType.CHAT,
+    )
 
     fun sendMessage() {
         focusManager.clearFocus(force = true)
@@ -264,13 +269,8 @@ fun ChatInput(
                                 horizontalArrangement = Arrangement.spacedBy(2.dp)
                             ) {
                                 // Model Picker
-                                ModelSelector(
-                                    modelId = assistant.chatModelId ?: settings.chatModelId,
-                                    providers = settings.providers,
-                                    onSelect = {
-                                        onUpdateChatModel(it)
-                                    },
-                                    type = ModelType.CHAT,
+                                ModelSelectorButton(
+                                    state = modelListState,
                                     onlyIcon = true,
                                     modifier = Modifier,
                                 )
@@ -368,6 +368,11 @@ fun ChatInput(
 
         }
     }
+
+    ModelListSheet(
+        state = modelListState,
+        onSelect = onUpdateChatModel,
+    )
 }
 
 @Composable

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
@@ -173,6 +173,29 @@ fun ModelSelector(
         providers = providers,
         type = type,
     )
+
+    ModelSelectorButton(
+        state = state,
+        modifier = modifier,
+        onlyIcon = onlyIcon,
+        allowClear = allowClear,
+        onClear = { onSelect(Model()) },
+    )
+
+    ModelListSheet(
+        state = state,
+        onSelect = onSelect,
+    )
+}
+
+@Composable
+internal fun ModelSelectorButton(
+    state: ModelListState,
+    modifier: Modifier = Modifier,
+    onlyIcon: Boolean = false,
+    allowClear: Boolean = false,
+    onClear: () -> Unit = {},
+) {
     val model = state.currentModel
 
     if (!onlyIcon) {
@@ -202,9 +225,7 @@ fun ModelSelector(
             }
             if (allowClear && model != null) {
                 IconButton(
-                    onClick = {
-                        onSelect(Model())
-                    }
+                    onClick = onClear,
                 ) {
                     Icon(
                         imageVector = HugeIcons.Cancel01,
@@ -234,11 +255,6 @@ fun ModelSelector(
             }
         }
     }
-
-    ModelListSheet(
-        state = state,
-        onSelect = onSelect,
-    )
 }
 
 @Composable

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TTSController.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TTSController.kt
@@ -1,6 +1,7 @@
 package me.rerere.rikkahub.ui.components.ui
 
 import androidx.compose.animation.AnimatedVisibility
+import com.dokar.sonner.ToastType
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -24,7 +25,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.ArrowLeft01
@@ -34,17 +34,26 @@ import me.rerere.hugeicons.stroke.Forward02
 import me.rerere.hugeicons.stroke.Pause
 import me.rerere.hugeicons.stroke.Play
 import me.rerere.rikkahub.ui.context.LocalTTSState
+import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.hooks.CustomTtsState
 import me.rerere.tts.model.PlaybackState
 import me.rerere.tts.model.PlaybackStatus
 
 @Composable
 fun TTSController() {
-    val context = LocalContext.current
     val ttsState = LocalTTSState.current
+    val toaster = LocalToaster.current
 
     val isSpeaking by ttsState.isSpeaking.collectAsState()
     var isVisible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(ttsState, toaster) {
+        ttsState.error.collect { error ->
+            if (error != null) {
+                toaster.show(message = error, type = ToastType.Error)
+            }
+        }
+    }
 
     LaunchedEffect(isSpeaking) {
         if (isSpeaking) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/workspace/WorkspaceTerminalPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/workspace/WorkspaceTerminalPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -25,6 +26,7 @@ import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -70,6 +72,7 @@ fun WorkspaceTerminalPage(id: String) {
     val terminalState by terminalStateFlow.collectAsStateWithLifecycle(
         initialValue = WorkspaceTerminalTabsState(),
     )
+    var pendingCloseTabId by remember(root) { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(root) {
         root?.let { sessionManager.ensureSession(it) }
@@ -114,7 +117,40 @@ fun WorkspaceTerminalPage(id: String) {
                     root?.let { sessionManager.selectTab(it, tabId) }
                 },
                 onCloseTab = { tabId ->
-                    root?.let { sessionManager.closeTab(it, tabId) }
+                    pendingCloseTabId = tabId
+                },
+            )
+        }
+
+        val pendingCloseTab = terminalState.tabs.firstOrNull { it.id == pendingCloseTabId }
+        if (pendingCloseTab != null) {
+            AlertDialog(
+                onDismissRequest = { pendingCloseTabId = null },
+                title = {
+                    Text(
+                        stringResource(
+                            R.string.workspace_terminal_close_confirm_title,
+                            pendingCloseTab.number,
+                        ),
+                    )
+                },
+                text = {
+                    Text(stringResource(R.string.workspace_terminal_close_confirm_message))
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            root?.let { sessionManager.closeTab(it, pendingCloseTab.id) }
+                            pendingCloseTabId = null
+                        },
+                    ) {
+                        Text(stringResource(R.string.workspace_terminal_close))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { pendingCloseTabId = null }) {
+                        Text(stringResource(R.string.common_cancel))
+                    }
                 },
             )
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/TTSProviderConfigure.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/TTSProviderConfigure.kt
@@ -559,7 +559,7 @@ private fun QwenTTSConfiguration(
 
     // Voice
     val voices = listOf(
-        "Cherry", "Serene", "Ethan", "Chelsie",
+        "Cherry", "Serena", "Ethan", "Chelsie",
         "Momo", "Vivian", "Moon", "Maia", "Kai",
         "Nofish", "Bella", "Jennifer", "Ryan",
         "Katerina", "Aiden", "Eldric Sage", "Mia",

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/TTSProviderConfigure.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/TTSProviderConfigure.kt
@@ -543,29 +543,46 @@ private fun QwenTTSConfiguration(
     }
 
     // Model
+    val models = listOf(
+        "qwen-audio-3.0-tts-flash",
+        "qwen-audio-3.0-tts-plus",
+    )
+
     FormItem(
         label = { Text(stringResource(R.string.setting_tts_page_model)) },
         description = { Text(stringResource(R.string.setting_tts_page_model_description)) }
     ) {
-        OutlinedTextField(
+        SelectTextField(
             value = setting.model,
+            options = models,
             onValueChange = { newModel ->
                 onValueChange(setting.copy(model = newModel))
             },
+            onOptionSelected = { model ->
+                val defaultVoice = when (model) {
+                    "qwen-audio-3.0-tts-plus" -> "longanlingxin"
+                    "qwen-audio-3.0-tts-flash" -> "longanhuan_v3.6"
+                    else -> setting.voice
+                }
+                onValueChange(setting.copy(model = model, voice = defaultVoice))
+            },
             modifier = Modifier.fillMaxWidth(),
-            placeholder = { Text("qwen3-tts-flash") }
+            placeholder = { Text("qwen-audio-3.0-tts-flash") }
         )
     }
 
     // Voice
-    val voices = listOf(
-        "Cherry", "Serena", "Ethan", "Chelsie",
-        "Momo", "Vivian", "Moon", "Maia", "Kai",
-        "Nofish", "Bella", "Jennifer", "Ryan",
-        "Katerina", "Aiden", "Eldric Sage", "Mia",
-        "Mochi", "Bellona", "Vincent", "Bunny",
-        "Neil", "Elias", "Arthur", "Nini"
-    )
+    val voices = when (setting.model) {
+        "qwen-audio-3.0-tts-plus" -> listOf("longanlingxin", "longanlufeng")
+        "qwen-audio-3.0-tts-flash" -> listOf(
+            "longanfengyue", "longanyuanfei", "longanlingxi", "longanxiaoxin",
+            "longanhuan_v3.6", "longjielidou_v3.6", "longpaopao_v3.6",
+            "longhuohuo_v3.6", "longchuanshu_v3.6", "loongmary",
+            "loongeva_v3.6", "loongjohn",
+        )
+
+        else -> emptyList()
+    }
 
     FormItem(
         label = { Text(stringResource(R.string.setting_tts_page_voice)) },
@@ -584,21 +601,37 @@ private fun QwenTTSConfiguration(
         )
     }
 
-    // Language Type
-    val languageTypes = listOf("Auto", "Chinese", "English", "Japanese", "Korean")
+    // Audio Format
+    val formats = listOf("wav", "mp3", "pcm", "opus")
 
     FormItem(
-        label = { Text("Language Type") },
-        description = { Text("Language type for TTS synthesis") }
+        label = { Text("Audio Format") },
+        description = { Text("Audio encoding returned by Qwen TTS") }
     ) {
         SelectTextField(
-            value = setting.languageType,
-            options = languageTypes,
-            onValueChange = { newLanguageType ->
-                onValueChange(setting.copy(languageType = newLanguageType))
+            value = setting.format,
+            options = formats,
+            readOnly = true,
+            onOptionSelected = { format ->
+                onValueChange(setting.copy(format = format))
             },
-            onOptionSelected = { languageType ->
-                onValueChange(setting.copy(languageType = languageType))
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+
+    // Sample Rate
+    val sampleRates = listOf(8000, 16000, 22050, 24000, 44100, 48000)
+
+    FormItem(
+        label = { Text("Sample Rate") },
+        description = { Text("Audio sample rate in Hz") }
+    ) {
+        SelectTextField(
+            value = setting.sampleRate.toString(),
+            options = sampleRates,
+            readOnly = true,
+            onOptionSelected = { sampleRate ->
+                onValueChange(setting.copy(sampleRate = sampleRate))
             },
             modifier = Modifier.fillMaxWidth()
         )

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1309,5 +1309,10 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="workspace_terminal_close_confirm_title">ターミナル %1$d を閉じますか？</string>
   <string name="workspace_terminal_close_confirm_message">このタブを閉じると、実行中のプロセスは終了します。</string>
   <string name="workspace_terminal_close">閉じる</string>
+  <string name="chat_generation_network_retrying">%1$s。再試行中（%2$d/%3$d）…</string>
+  <string name="chat_generation_network_unknown_host">サーバーアドレスを解決できません</string>
+  <string name="chat_generation_network_timeout">接続がタイムアウトしました</string>
+  <string name="chat_generation_network_unreachable">サーバーに接続できません</string>
+  <string name="chat_generation_network_disconnected">ネットワーク接続が切断されました</string>
 </resources>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1306,5 +1306,8 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="setting_provider_page_test_tool_call">ツール呼び出し</string>
   <string name="setting_provider_page_test_tool_called">呼び出し: %1$s  引数: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">ツールが呼び出されませんでした。応答: %s</string>
+  <string name="workspace_terminal_close_confirm_title">ターミナル %1$d を閉じますか？</string>
+  <string name="workspace_terminal_close_confirm_message">このタブを閉じると、実行中のプロセスは終了します。</string>
+  <string name="workspace_terminal_close">閉じる</string>
 </resources>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1309,5 +1309,10 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="workspace_terminal_close_confirm_title">터미널 %1$d번을 닫으시겠습니까?</string>
   <string name="workspace_terminal_close_confirm_message">이 탭을 닫으면 실행 중인 프로세스가 종료됩니다.</string>
   <string name="workspace_terminal_close">닫기</string>
+    <string name="chat_generation_network_retrying">%1$s. 재시도 중 (%2$d/%3$d)…</string>
+    <string name="chat_generation_network_unknown_host">서버 주소를 확인할 수 없습니다</string>
+    <string name="chat_generation_network_timeout">연결 시간이 초과되었습니다</string>
+    <string name="chat_generation_network_unreachable">서버에 연결할 수 없습니다</string>
+    <string name="chat_generation_network_disconnected">네트워크 연결이 끊어졌습니다</string>
 </resources>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1306,5 +1306,8 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="setting_provider_page_test_tool_call">도구 호출</string>
   <string name="setting_provider_page_test_tool_called">호출: %1$s  인수: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">도구가 호출되지 않음, 응답: %s</string>
+  <string name="workspace_terminal_close_confirm_title">터미널 %1$d번을 닫으시겠습니까?</string>
+  <string name="workspace_terminal_close_confirm_message">이 탭을 닫으면 실행 중인 프로세스가 종료됩니다.</string>
+  <string name="workspace_terminal_close">닫기</string>
 </resources>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1309,5 +1309,10 @@
   <string name="workspace_terminal_close_confirm_title">Закрыть терминал %1$d?</string>
   <string name="workspace_terminal_close_confirm_message">Закрытие этой вкладки приведет к завершению всех процессов, которые все еще в ней выполняются.</string>
   <string name="workspace_terminal_close">Закрыть</string>
+    <string name="chat_generation_network_retrying">%1$s. Повторная попытка (%2$d/%3$d)…</string>
+    <string name="chat_generation_network_unknown_host">Не удалось разрешить адрес сервера</string>
+    <string name="chat_generation_network_timeout">Тайм-аут соединения</string>
+    <string name="chat_generation_network_unreachable">Не удается подключиться к серверу</string>
+    <string name="chat_generation_network_disconnected">Сетевое соединение потеряно</string>
 </resources>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1306,5 +1306,8 @@
   <string name="setting_provider_page_test_tool_call">Вызов инструмента</string>
   <string name="setting_provider_page_test_tool_called">Вызвано: %1$s  Аргументы: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">Инструмент не вызван, ответ: %s</string>
+  <string name="workspace_terminal_close_confirm_title">Закрыть терминал %1$d?</string>
+  <string name="workspace_terminal_close_confirm_message">Закрытие этой вкладки приведет к завершению всех процессов, которые все еще в ней выполняются.</string>
+  <string name="workspace_terminal_close">Закрыть</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1304,5 +1304,8 @@
   <string name="setting_provider_page_test_tool_call">工具呼叫</string>
   <string name="setting_provider_page_test_tool_called">已調用：%1$s  參數：%2$s</string>
   <string name="setting_provider_page_test_tool_not_called">工具未被呼叫，回應：%s</string>
+  <string name="workspace_terminal_close_confirm_title">關閉終端機 %1$d？</string>
+  <string name="workspace_terminal_close_confirm_message">關閉此分頁將終止仍在其中執行的任何程序。</string>
+  <string name="workspace_terminal_close">關閉</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1307,5 +1307,10 @@
   <string name="workspace_terminal_close_confirm_title">關閉終端機 %1$d？</string>
   <string name="workspace_terminal_close_confirm_message">關閉此分頁將終止仍在其中執行的任何程序。</string>
   <string name="workspace_terminal_close">關閉</string>
+    <string name="chat_generation_network_retrying">%1$s，正在重試（%2$d/%3$d）…</string>
+    <string name="chat_generation_network_unknown_host">無法解析伺服器位址</string>
+    <string name="chat_generation_network_timeout">連線逾時</string>
+    <string name="chat_generation_network_unreachable">無法連線到伺服器</string>
+    <string name="chat_generation_network_disconnected">網路連線已中斷</string>
 </resources>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1314,5 +1314,10 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="workspace_terminal_close_confirm_title">关闭终端 %1$d？</string>
   <string name="workspace_terminal_close_confirm_message">关闭此标签页将终止其中仍在运行的任何进程。</string>
   <string name="workspace_terminal_close">关闭</string>
+    <string name="chat_generation_network_retrying">%1$s，正在重试（%2$d/%3$d）…</string>
+    <string name="chat_generation_network_unknown_host">无法解析服务器地址</string>
+    <string name="chat_generation_network_timeout">连接超时</string>
+    <string name="chat_generation_network_unreachable">无法连接到服务器</string>
+    <string name="chat_generation_network_disconnected">网络连接已断开</string>
 </resources>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1311,5 +1311,8 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="setting_provider_page_test_tool_call">工具调用</string>
   <string name="setting_provider_page_test_tool_called">已调用: %1$s  参数: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">未调用工具，响应：%s</string>
+  <string name="workspace_terminal_close_confirm_title">关闭终端 %1$d？</string>
+  <string name="workspace_terminal_close_confirm_message">关闭此标签页将终止其中仍在运行的任何进程。</string>
+  <string name="workspace_terminal_close">关闭</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1320,5 +1320,10 @@
   <string name="setting_provider_page_test_tool_call">Tool Call</string>
   <string name="setting_provider_page_test_tool_called">Called: %1$s  Args: %2$s</string>
   <string name="setting_provider_page_test_tool_not_called">Tool not called, response: %s</string>
+  <string name="chat_generation_network_retrying">%1$s. Retrying (%2$d/%3$d)…</string>
+  <string name="chat_generation_network_unknown_host">Unable to resolve server address</string>
+  <string name="chat_generation_network_timeout">Connection timed out</string>
+  <string name="chat_generation_network_unreachable">Unable to connect to server</string>
+  <string name="chat_generation_network_disconnected">Network connection lost</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1228,6 +1228,9 @@
   <string name="workspace_terminal_tab">Terminal %1$d</string>
   <string name="workspace_terminal_new_tab">New terminal tab</string>
   <string name="workspace_terminal_close_tab">Close terminal %1$d</string>
+  <string name="workspace_terminal_close_confirm_title">Close terminal %1$d?</string>
+  <string name="workspace_terminal_close_confirm_message">Closing this tab will terminate any process still running in it.</string>
+  <string name="workspace_terminal_close">Close</string>
   <string name="workspace_terminal_no_tabs">No open terminal tabs</string>
   <string name="extensions_page_workspace">Workspace</string>
   <string name="extensions_page_workspace_desc">Manage local working directories accessible by Agent</string>

--- a/app/src/test/java/me/ayuilos/miffan/ui/pages/chat/ChatWorkspaceTopBarTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/ui/pages/chat/ChatWorkspaceTopBarTest.kt
@@ -1,0 +1,88 @@
+package me.ayuilos.miffan.ui.pages.chat
+
+import me.ayuilos.miffan.data.db.entity.WorkspaceEntity
+import me.rerere.workspace.WorkspaceShellStatus
+import me.rerere.workspace.WorkspaceStorageArea
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatWorkspaceTopBarTest {
+    @Test
+    fun unboundAssistantHasNoWorkspaceEntry() {
+        assertNull(resolveChatWorkspaceEntry(boundWorkspaceId = null, workspace = null))
+    }
+
+    @Test
+    fun availableWorkspaceKeepsItsNameWithoutWarning() {
+        val entry = resolveChatWorkspaceEntry(
+            boundWorkspaceId = "workspace-id",
+            workspace = workspace(shellStatus = WorkspaceShellStatus.READY.name),
+        )
+
+        assertEquals("workspace-id", entry?.id)
+        assertEquals("Project files", entry?.name)
+        assertFalse(entry?.warning ?: true)
+    }
+
+    @Test
+    fun filesOnlyWorkspaceDoesNotShowWarningWhenShellIsDisabled() {
+        val entry = resolveChatWorkspaceEntry(
+            boundWorkspaceId = "workspace-id",
+            workspace = workspace(shellStatus = WorkspaceShellStatus.DISABLED.name),
+        )
+
+        assertFalse(entry?.warning ?: true)
+    }
+
+    @Test
+    fun brokenOrMissingWorkspaceRemainsVisibleWithWarning() {
+        val broken = resolveChatWorkspaceEntry(
+            boundWorkspaceId = "workspace-id",
+            workspace = workspace(shellStatus = WorkspaceShellStatus.BROKEN.name),
+        )
+        val missing = resolveChatWorkspaceEntry(
+            boundWorkspaceId = "workspace-id",
+            workspace = null,
+        )
+
+        assertTrue(broken?.warning == true)
+        assertEquals("workspace-id", missing?.id)
+        assertTrue(missing?.warning == true)
+    }
+
+    @Test
+    fun workspaceCwdIsConvertedToFilesAreaPath() {
+        assertEquals("", workspaceCwdToFilesPath(null))
+        assertEquals("", workspaceCwdToFilesPath("/workspace"))
+        assertEquals("project/docs", workspaceCwdToFilesPath("/workspace/project/docs/"))
+        assertEquals("project/docs", workspaceCwdToFilesPath("workspace\\project\\docs"))
+    }
+
+    @Test
+    fun invalidWorkspaceCwdFallsBackToWorkspaceRoot() {
+        assertEquals("", workspaceCwdToFilesPath("/tmp/project"))
+        assertEquals("", workspaceCwdToFilesPath("project/../secret"))
+    }
+
+    @Test
+    fun workspaceRouteOpensFilesAtConversationCwd() {
+        val route = workspaceFilesRoute("workspace-id", "/workspace/project")
+
+        assertEquals("workspace-id", route.id)
+        assertEquals(WorkspaceStorageArea.FILES.name, route.area)
+        assertEquals("project", route.path)
+        assertTrue(route.openFiles)
+    }
+
+    private fun workspace(shellStatus: String) = WorkspaceEntity(
+        id = "workspace-id",
+        name = "Project files",
+        root = "workspace-root",
+        shellStatus = shellStatus,
+        createdAt = 1L,
+        updatedAt = 1L,
+    )
+}

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformerTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformerTest.kt
@@ -351,6 +351,7 @@ class PromptInjectionTransformerTest {
         )
 
         assertEquals(2, result.size)
+        assertTrue(result[0].isSynthetic)
         val systemText = getMessageText(result[0])
         assertTrue(systemText.startsWith("Original system prompt"))
         assertTrue(systemText.endsWith("Appended content"))
@@ -408,6 +409,7 @@ class PromptInjectionTransformerTest {
 
         assertEquals(3, result.size)
         assertEquals(MessageRole.SYSTEM, result[0].role)
+        assertTrue(result[0].isSynthetic)
         assertEquals("New system content", getMessageText(result[0]))
     }
     // endregion
@@ -439,6 +441,7 @@ class PromptInjectionTransformerTest {
         assertEquals(MessageRole.SYSTEM, result[0].role)
         assertEquals("System prompt", getMessageText(result[0]))
         assertEquals(MessageRole.USER, result[1].role)
+        assertTrue(result[1].isSynthetic)
         assertEquals("Top of chat content", getMessageText(result[1]))
         assertEquals(MessageRole.USER, result[2].role)
     }

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformerTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformerTest.kt
@@ -25,6 +25,7 @@ class TimeReminderTransformerTest {
         val messages = listOf(userMessage("Hello", LocalDateTime(2026, 2, 22, 10, 0, 0)))
         val result = applyTimeReminder(messages)
         assertEquals(2, result.size)
+        assertTrue(result[0].isSynthetic)
         assertTrue(getMessageText(result[0]).contains("<time_reminder>"))
         assertFalse(getMessageText(result[0]).contains("since last message"))
         assertEquals("Hello", getMessageText(result[1]))

--- a/docs/releases/3.0.3.md
+++ b/docs/releases/3.0.3.md
@@ -1,0 +1,31 @@
+更新内容：
+
+### Miffan 自有改动
+
+- 在绑定了 Workspace 的聊天顶部栏新增文件区快捷入口；工作区缺失或 Shell 状态异常时会显示警告。
+
+### 同步自 RikkaHub
+
+- 临时网络故障时自动重试模型请求，并显示清晰的重试进度。
+- 提升后台聊天生成稳定性，切换到其他应用后流式回复更不易中断。
+- 新增 Qwen 3.8 和 Hy4 模型匹配。
+- 适配 Qwen Audio 3.0 文本转语音，修复预置音色列表，并直接提示播放错误。
+- 修复打开键盘后模型搜索界面自动关闭的问题。
+- 修复内部合成消息被消息模板重复处理的问题，减少意外提示词污染。
+- 改进 Workspace 终端安全性与可靠性：关闭前先确认，无标准输入的非交互命令会立即收到 EOF，避免 CLI 工具持续阻塞。
+
+Updates:
+
+### Miffan changes
+
+- Added a Files shortcut to the chat top bar when a Workspace is bound; a warning appears when the Workspace is missing or its shell is unavailable.
+
+### Synced from RikkaHub
+
+- Automatically retry model requests after transient network failures and show clear retry progress.
+- Improved background chat generation stability so streaming responses are less likely to stop after switching apps.
+- Added Qwen 3.8 and Hy4 model matching.
+- Added Qwen Audio 3.0 text-to-speech support, fixed the preset voice list, and surfaced playback errors.
+- Fixed the model search interface closing unexpectedly when the keyboard opens.
+- Fixed internal synthetic messages being processed repeatedly by message templates, reducing unintended prompt contamination.
+- Improved Workspace terminal safety and reliability: closing now requires confirmation, and non-interactive commands without standard input receive EOF immediately to prevent CLI tools from hanging.

--- a/speech/src/main/java/me/rerere/tts/provider/TTSProviderSetting.kt
+++ b/speech/src/main/java/me/rerere/tts/provider/TTSProviderSetting.kt
@@ -103,10 +103,11 @@ sealed class TTSProviderSetting {
         override var id: Uuid = Uuid.random(),
         override var name: String = "Qwen TTS",
         val apiKey: String = "",
-        val baseUrl: String = "https://dashscope.aliyuncs.com/api/v1",
-        val model: String = "qwen3-tts-flash",
-        val voice: String = "Cherry",
-        val languageType: String = "Auto"
+        val baseUrl: String = "https://{WorkspaceId}.cn-beijing.maas.aliyuncs.com/api/v1",
+        val model: String = "qwen-audio-3.0-tts-flash",
+        val voice: String = "longanhuan_v3.6",
+        val format: String = "wav",
+        val sampleRate: Int = 24000,
     ) : TTSProviderSetting() {
         override fun copyProvider(
             id: Uuid,

--- a/speech/src/main/java/me/rerere/tts/provider/providers/QwenTTSProvider.kt
+++ b/speech/src/main/java/me/rerere/tts/provider/providers/QwenTTSProvider.kt
@@ -29,75 +29,71 @@ class QwenTTSProvider : TTSProvider<TTSProviderSetting.Qwen> {
         providerSetting: TTSProviderSetting.Qwen,
         request: TTSRequest
     ): Flow<AudioChunk> = flow {
+        require(!providerSetting.model.startsWith("qwen3-tts")) {
+            "旧版 Qwen3 TTS 模型已不再支持，请在 TTS 设置中改用 qwen-audio-3.0-tts-plus 或 qwen-audio-3.0-tts-flash"
+        }
+        require(!providerSetting.baseUrl.contains("{WorkspaceId}")) {
+            "请在 Base URL 中将 {WorkspaceId} 替换为阿里云百炼业务空间 ID"
+        }
+
         val requestBody = JSONObject().apply {
             put("model", providerSetting.model)
             put("input", JSONObject().apply {
                 put("text", request.text)
                 put("voice", providerSetting.voice)
-                put("language_type", providerSetting.languageType)
+                put("format", providerSetting.format)
+                put("sample_rate", providerSetting.sampleRate)
             })
         }
 
         Log.i(TAG, "generateSpeech: $requestBody")
 
         val httpRequest = Request.Builder()
-            .url("${providerSetting.baseUrl}/services/aigc/multimodal-generation/generation")
+            .url("${providerSetting.baseUrl.trimEnd('/')}/services/audio/tts/SpeechSynthesizer")
             .addHeader("Authorization", "Bearer ${providerSetting.apiKey}")
             .addHeader("Content-Type", "application/json")
             .addHeader("X-DashScope-SSE", "enable")
             .post(requestBody.toString().toRequestBody("application/json".toMediaType()))
             .build()
 
-        val response = httpClient.newCall(httpRequest).execute()
+        httpClient.newCall(httpRequest).execute().use { response ->
+            if (!response.isSuccessful) {
+                val errorBody = response.body.string()
+                Log.e(
+                    TAG,
+                    "Qwen TTS request failed: ${response.code} ${response.message}, body: $errorBody"
+                )
+                throw Exception("Qwen TTS request failed: ${response.code} ${response.message}")
+            }
 
-        if (!response.isSuccessful) {
-            val errorBody = response.body.string()
-            Log.e(TAG, "Qwen TTS request failed: ${response.code} ${response.message}, body: $errorBody")
-            throw Exception("Qwen TTS request failed: ${response.code} ${response.message}")
-        }
+            response.body.byteStream().bufferedReader().use { reader ->
+                var currentData = StringBuilder()
 
-        val reader = response.body.byteStream().bufferedReader()
-
-        try {
-            var currentData = StringBuilder()
-
-            reader.lineSequence().forEach { line ->
-                when {
-                    line.startsWith("data:") -> {
-                        currentData.append(line.removePrefix("data:"))
-                    }
-
-                    line.isEmpty() && currentData.isNotEmpty() -> {
-                        val result = parseSSEData(currentData.toString())
-                        if (result != null) {
-                            val (audioData, isLast) = result
-                            emit(
-                                AudioChunk(
-                                    data = audioData,
-                                    format = AudioFormat.PCM,
-                                    sampleRate = 24000,
-                                    isLast = isLast,
-                                    metadata = mapOf(
-                                        "provider" to "qwen",
-                                        "model" to providerSetting.model,
-                                        "voice" to providerSetting.voice,
-                                        "sampleRate" to "24000",
-                                        "channels" to "1",
-                                        "bitDepth" to "16"
-                                    )
-                                )
-                            )
+                reader.lineSequence().forEach { line ->
+                    when {
+                        line.startsWith("data:") -> {
+                            currentData.append(line.removePrefix("data:").trimStart())
                         }
-                        currentData = StringBuilder()
+
+                        line.isEmpty() && currentData.isNotEmpty() -> {
+                            parseSSEData(currentData.toString(), providerSetting)?.let { emit(it) }
+                            currentData = StringBuilder()
+                        }
                     }
                 }
+
+                // 兼容最后一个 SSE event 后没有空行、直接 EOF 的响应。
+                if (currentData.isNotEmpty()) {
+                    parseSSEData(currentData.toString(), providerSetting)?.let { emit(it) }
+                }
             }
-        } finally {
-            reader.close()
         }
     }
 
-    private fun parseSSEData(data: String): Pair<ByteArray, Boolean>? {
+    private fun parseSSEData(
+        data: String,
+        providerSetting: TTSProviderSetting.Qwen,
+    ): AudioChunk? {
         return try {
             val json = JSONObject(data)
             val output = json.optJSONObject("output") ?: return null
@@ -108,7 +104,24 @@ class QwenTTSProvider : TTSProvider<TTSProviderSetting.Qwen> {
             if (audioBase64.isNotEmpty()) {
                 val audioData = Base64.decode(audioBase64, Base64.DEFAULT)
                 val isLast = finishReason == "stop"
-                Pair(audioData, isLast)
+                AudioChunk(
+                    data = audioData,
+                    format = when (providerSetting.format.lowercase()) {
+                        "mp3" -> AudioFormat.MP3
+                        "pcm" -> AudioFormat.PCM
+                        "opus" -> AudioFormat.OPUS
+                        else -> AudioFormat.WAV
+                    },
+                    sampleRate = providerSetting.sampleRate,
+                    isLast = isLast,
+                    metadata = mapOf(
+                        "provider" to "qwen",
+                        "model" to providerSetting.model,
+                        "voice" to providerSetting.voice,
+                        "format" to providerSetting.format,
+                        "sampleRate" to providerSetting.sampleRate.toString(),
+                    )
+                )
             } else {
                 null
             }

--- a/workspace/src/main/java/me/rerere/workspace/ProotShellRunner.kt
+++ b/workspace/src/main/java/me/rerere/workspace/ProotShellRunner.kt
@@ -95,6 +95,10 @@ class ProotShellRunner(
             "TERM=xterm-256color",
             "LANG=C.UTF-8",
             "LC_ALL=C.UTF-8",
+            // 非交互执行约定, 抑制各类 CLI 的交互行为 (确认提示/分页器/颜色转义)
+            "CI=true",
+            "NO_COLOR=1",
+            "PAGER=cat",
             "/bin/bash",
             "-l",
             "-c",

--- a/workspace/src/main/java/me/rerere/workspace/WorkspaceShellRunner.kt
+++ b/workspace/src/main/java/me/rerere/workspace/WorkspaceShellRunner.kt
@@ -42,6 +42,15 @@ fun Process.readResult(timeoutMillis: Long, stdin: ByteArray? = null): Workspace
     val stdout = StreamCollector(inputStream)
     val stderr = StreamCollector(errorStream)
     val stdinWriter = stdin?.let { bytes -> StreamWriter(outputStream, bytes) }
+    if (stdinWriter == null) {
+        // 没有 stdin 输入时立即关闭管道, 让子进程读到 EOF;
+        // 否则 cat/gh/kubectl 等按 isatty 判断的工具会把这根永不写入的管道当成待输入流而永久阻塞
+        try {
+            outputStream.close()
+        } catch (_: IOException) {
+            // 子进程已提前退出导致管道关闭, 忽略
+        }
+    }
     try {
         val finished = waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
         if (!finished) {

--- a/workspace/src/test/java/me/rerere/workspace/ExampleUnitTest.kt
+++ b/workspace/src/test/java/me/rerere/workspace/ExampleUnitTest.kt
@@ -118,6 +118,25 @@ class ExampleUnitTest {
     }
 
     @Test
+    fun commandWithoutStdinGetsImmediateEof() {
+        val baseDir = Files.createTempDirectory("workspace-stdin-eof-test").toFile()
+        val manager = WorkspaceManager(baseDir)
+        val root = "test-workspace"
+        manager.ensureWorkspace(root)
+
+        // 不传 stdin 时子进程的 stdin 应立即 EOF; cat 会直接退出而不是等管道输入
+        val result = manager.executeCommand(
+            root = root,
+            command = "cat",
+            timeoutMillis = 10_000,
+        )
+
+        assertFalse(result.timedOut)
+        assertEquals(0, result.exitCode)
+        assertEquals("", result.stdout)
+    }
+
+    @Test
     fun prootRunnerRequiresRootfs() {
         val baseDir = Files.createTempDirectory("workspace-proot-test").toFile()
         val manager = WorkspaceManager(


### PR DESCRIPTION
Prepare Miffan 3.0.3 with the workspace chat shortcut, the latest reviewed upstream synchronization, versionCode 178006, and the confirmed bilingual release notes. Verification completed locally: assembleDebug, all JVM tests, and Android Lint.