### PR TITLE
Sync RikkaHub through 2.4.13

### DIFF
--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -478,6 +478,17 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
+    private val GLM_5_3 = defineModel {
+        tokens("glm", "5", "3")
+        toolReasoningAbility()
+    }
+
+    private val GLM_5_3_FLASH = defineModel {
+        tokens("glm", "5", "3", "flash")
+        visionInput()
+        toolReasoningAbility()
+    }
+
     private val MINIMAX_M2 = defineModel {
         tokens("minimax", "m", "2")
         toolReasoningAbility()
@@ -639,6 +650,8 @@ object ModelRegistry {
         GLM_5,
         GLM_5_1,
         GLM_5_2,
+        GLM_5_3,
+        GLM_5_3_FLASH,
         MINIMAX_M2,
         MINIMAX_M2_5,
         MINIMAX_M2_7,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "me.rerere.rikkahub"
         minSdk = 26
         targetSdk = 37
-        versionCode = 179
-        versionName = "2.4.12"
+        versionCode = 180
+        versionName = "2.4.13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Upstream provenance

- upstream base: c16fe44ff98f123288d8d401c58f8ac77a5cd818
- upstream end: 170a612e9ee8e11fb181b3059f9208f13b2c334a
- integration: topology-preserving merge of the complete upstream range

## Incorporated changes

- register GLM 5.3 with tool and reasoning capabilities
- register GLM 5.3 Flash with vision, tool, and reasoning capabilities

## Excluded or resolved areas

- rejected the upstream 2.4.13 versionName and versionCode during the single app/build.gradle.kts conflict
- preserved the Miffan package identity, version line 3.0.3 / 178006, Firebase switch, release signing, update source, branding, and deep links
- no upstream tags were fetched or propagated

## Verification

- ./gradlew test lint assembleDebug --stacktrace