### PR TITLE
Release Miffan 3.0.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "me.ayuilos.miffan.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 178006
-        versionName = "3.0.3"
+        versionCode = 178007
+        versionName = "3.0.4"
 
         buildConfigField("boolean", "FIREBASE_ENABLED", hasGoogleServicesConfig.toString())
 

--- a/docs/releases/3.0.4.md
+++ b/docs/releases/3.0.4.md
@@ -1,0 +1,23 @@
+# 3.0.4
+
+更新内容：
+
+### Miffan 自有改动
+
+- 新绑定工作区的 Assistant 现在拥有独立文件 Scope；文件、Skills、对话产物及 Home/临时目录彼此隔离。现有绑定继续使用兼容模式，不会移动或隐藏已有文件。
+- Shell 确认设置现在按 Assistant Scope 独立保存；界面同时明确提示，同一工作区中的 Rootfs、已安装软件及 `/etc`、`/usr` 等系统路径仍由所有绑定的 Assistant 共享。
+
+### 同步自 RikkaHub
+
+- 新增 GLM 5.3 与 GLM 5.3 Flash 的模型能力识别，包括工具调用、推理能力，以及 Flash 版本的视觉输入能力。
+
+Updates:
+
+### Miffan changes
+
+- Assistants newly bound to a workspace now receive isolated file scopes for files, Skills, chat artifacts, home directories, and temporary files. Existing bindings remain in compatibility mode without moving or hiding existing data.
+- Shell confirmation preferences are now stored per Assistant scope. The UI also clarifies that the Rootfs, installed software, and system paths such as `/etc` and `/usr` remain shared by assistants bound to the same workspace.
+
+### Synced from RikkaHub
+
+- Added capability recognition for GLM 5.3 and GLM 5.3 Flash, including tool use, reasoning, and vision input for the Flash variant.


### PR DESCRIPTION
## Summary

- bump Miffan to 3.0.4 (versionCode 178007)
- add the confirmed bilingual 3.0.4 release notes
- keep Miffan identity, signing, and production configuration unchanged

## Verification

- ./gradlew test lint assembleDebug --stacktrace
- BUILD SUCCESSFUL (565 actionable tasks)