### PR TITLE
Prepare Miffan 3.0.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "me.ayuilos.miffan.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 178007
-        versionName = "3.0.4"
+        versionCode = 178008
+        versionName = "3.0.5"
 
         buildConfigField("boolean", "FIREBASE_ENABLED", hasGoogleServicesConfig.toString())
 

--- a/docs/releases/3.0.5.md
+++ b/docs/releases/3.0.5.md
@@ -1,0 +1,33 @@
+# 3.0.5
+
+更新内容：
+
+### Miffan 自有改动
+
+- 新增按对话管理的消息队列：回复期间可以继续提交消息，并可移除或立即发送待发消息；停止或出错后保留队列，支持恢复发送。待发队列仅在本次应用运行期间保留。
+- 聊天顶部改为独立悬浮玻璃胶囊，优化不同主题下的对比度，并放大等待回复时的 Miffan。
+- Miffan 表情、视线和点击反馈衔接更自然，空白对话到等待回复的切换保持连贯；历史头像保持安静，并实时遵循系统关闭动画设置。
+- 引导助手将新生成的工作区产物按对话归档，后续轮次复用同一目录；保留用户指定路径和原地编辑项目的行为。
+- Chatbox 导入继续兼容旧版 JSON 备份，保留已有会话标识和重复导入跳过行为。
+
+### 同步自 RikkaHub
+
+- 支持 Chatbox Backup v2 ZIP 备份导入，包括提供商和模型配置、图片、系统提示词及可转换的消息分支。
+- MiMo 语音合成支持快捷选择预设音色，同时保留自定义输入。
+- 更新 Kimi 提供商图标；新配置不再默认添加 RikkaHub 提供商，已有保存配置保持不变。
+
+Updates:
+
+### Miffan changes
+
+- Added per-conversation message queues: submit follow-ups while a reply is running, remove queued messages, or send one immediately. Queues remain available after stopping or errors and can be resumed; unsent queues are retained only for the current app session.
+- Introduced separate floating glass capsules in the chat header, improved contrast across themes, and enlarged Miffan while waiting for a reply.
+- Smoothed Miffan's expressions, gaze, tap feedback, and transition from an empty conversation to a waiting reply. Historical avatars stay still, and system animation settings are respected live.
+- Guide assistants to organize newly generated workspace artifacts by conversation and reuse the same directory across turns, while preserving explicitly requested paths and in-place project edits.
+- Kept support for legacy Chatbox JSON backups, preserving existing conversation IDs and duplicate-import skipping.
+
+### Synced from RikkaHub
+
+- Added Chatbox Backup v2 ZIP import, including provider and model settings, images, system prompts, and convertible message branches.
+- Added preset voice selection for MiMo text-to-speech while retaining custom voice input.
+- Updated the Kimi provider icon. New configurations no longer add the RikkaHub provider by default; existing saved configurations remain unchanged.

--- a/docs/upstream-sync/2026-08-28.md
+++ b/docs/upstream-sync/2026-08-28.md
@@ -44,7 +44,7 @@ These commits become ancestors of the sync merge even when their content is excl
 ## Verification
 
 - The online `./gradlew test lint assembleDebug :app:assembleDebugAndroidTest --stacktrace` completed 300 app JVM tests and built the Debug APK/test APK. Lint then waited in a Maven-metadata TLS handshake, confirmed by a Gradle thread dump; that invocation was interrupted.
-- Re-run the same checks with `--offline` and the existing dependency cache, without disabling Lint checks or changing source/dependencies. Remote pull-request CI must still run the normal online command.
+- Passed `./gradlew --offline test lint assembleDebug :app:assembleDebugAndroidTest --stacktrace` in 2m 53s using the existing dependency cache, without disabling Lint checks or changing source/dependencies. Remote pull-request CI must still run the normal online command.
 - Passed all 12 focused emulator tests: legacy Chatbox import, floating chat controls, and Miffan motion on API 35 with 16 KB memory pages. Reviewed the generated theme/mascot screenshots; the temporary emulator was closed without saving changes.
 - Confirm no effective diff in app identity/version/signing, database migrations, dependency versions, release/nightly workflows, or the preserved chat/settings UI files.
 - Pull-request CI and Miffan review are still required before merging into remote `master`.


### PR DESCRIPTION
## Release preparation

- Candidate version: `3.0.5`, Android `versionCode 178008`.
- Release preparation commit: `a29ec6c2cdee939a895c367debaf6ba5270a169d`.
- The user explicitly approved this version and the bilingual contents of `docs/releases/3.0.5.md` before publication.
- Preserve the approved notes unchanged, with Miffan-owned changes separate from effective RikkaHub changes.
- This branch is based on the reviewed upstream sync from PR #15; the sync must be merged before this release PR.

## Validation

- Complete local `test lint assembleDebug :app:assembleDebugAndroidTest` passed with the existing offline dependency cache after online Maven metadata lookups stalled.
- All 300 app JVM tests and the candidate Debug APK build passed again after the version change.
- All 12 focused Android tests passed on API 35 / 16 KB memory pages, covering legacy Chatbox import, floating chat controls, and Miffan motion.
- Normal online PR CI is required before merge; production signing, APK identity/ABI, checksums, build provenance, and in-place upgrade verification remain release gates.

## Production boundary

After this PR's CI passes and it is merged into `master`, dispatch the production workflow using its exact merge SHA, `3.0.5`, and `178008`. Do not build a moving branch head or reuse the previous local release APK. Publish only the verified arm64 APK and checksum, without replacing existing tags or releases.
