### PR TITLE
ci: automatically mirror stable APK releases to R2

### DIFF
--- a/.github/R2_PUBLISHING.md
+++ b/.github/R2_PUBLISHING.md
@@ -1,0 +1,81 @@
+# Automatic APK mirror to Cloudflare R2
+
+After a **stable GitHub Release is published**, the **Publish APK to R2** workflow copies its original ARM64 APK and checksum to:
+
+- Bucket: `miffan-releases`
+- Download origin: https://downloads.ayuilos.me
+- Website manifest: https://downloads.ayuilos.me/latest.json
+
+The website reads the manifest on each visit, so an APK release does not require a website redeploy. This workflow does not rebuild or re-sign the APK, publish draft releases, change the Android in-app updater, or modify DNS/mail settings.
+
+## One-time activation
+
+1. Merge the workflow and scripts into `master` before creating the next release tag.
+2. In Cloudflare R2, create a dedicated token named **Miffan GitHub release mirror**:
+   - Permission: **Object Read & Write**, not Admin Read & Write.
+   - Scope: **only the `miffan-releases` bucket**.
+   - Keep the account endpoint used in the script; do not grant DNS or other account permissions.
+3. In [Miffan Actions secrets](https://github.com/Ayuilos/Miffan/settings/secrets/actions), store:
+   - `MIFFAN_R2_ACCESS_KEY_ID`: the R2 **Access Key ID**.
+   - `MIFFAN_R2_SECRET_ACCESS_KEY`: the R2 **Secret Access Key**.
+   - These are the S3 credentials, **not** the API token value, a Global API Key, or the local Wrangler OAuth login.
+4. Run **Publish APK to R2** manually on `master`, using the current stable tag, to verify the integration once. Check that both jobs succeed and the workflow summary links to the correct download.
+
+Never paste keys into chat, source files, workflow YAML, release notes, or command arguments. The GitHub CLI can prompt for them without adding them to shell history:
+
+```sh
+gh secret set MIFFAN_R2_ACCESS_KEY_ID --repo Ayuilos/Miffan
+gh secret set MIFFAN_R2_SECRET_ACCESS_KEY --repo Ayuilos/Miffan
+```
+
+The local Wrangler OAuth session cannot provide unattended GitHub Actions authentication. Bucket-scoped R2 credentials work with the S3 API; the Cloudflare management REST API requires broader permissions, so this workflow uses the runner's AWS CLI instead.
+
+## Normal release flow
+
+1. Use the existing **Prepare Production Release** workflow and its production approval/signing checks.
+2. Review and publish the draft as a **stable** release; mark the intended version as GitHub's latest.
+3. The mirror runs automatically. Draft, RC, nightly and other prerelease builds never replace the website's stable download.
+
+The current production workflow only creates a draft; its protected production Environment and signing keys are unchanged. If a future workflow publishes releases with `GITHUB_TOKEN`, that publish event will not trigger another workflow. It must explicitly dispatch `publish-r2.yml` after publication instead. A normal dashboard publish or the user's authenticated GitHub CLI publish triggers this workflow.
+
+## Safety and retry behavior
+
+- Only the fixed repository, account, bucket, domain and ARM64 filename format are accepted.
+- The original APK is checked against GitHub's asset digest and its published checksum.
+- Versioned objects are create-only. An existing object must have identical bytes.
+- The public APK is downloaded and checked before the latest pointer can change.
+- The manifest comes from the authoritative S3 endpoint and updates use ETag conditional writes. Concurrent changes fail safely.
+- Semantic-version and publication-date checks prevent older releases replacing newer ones.
+- Only GitHub's current latest stable release may become the website latest.
+- Reruns are idempotent; failed uploads can be retried without changing the APK.
+- The credentialed job checks out trusted `master`, never arbitrary tag code. PR tests have no R2 credentials. Official checkout/setup actions are pinned to commit SHAs.
+- No cache purge is needed: APK URLs are versioned and immutable; the latest manifest uses `no-cache`.
+
+If a run fails, the previous latest remains usable unless only the final public-manifest verification failed after a successful pointer write. Inspect the error and rerun the workflow on `master` with the same stable tag. Do not overwrite an APK or edit a release digest to force a retry. If a token is revoked, rotate the two GitHub secrets and rerun.
+
+Manual retry from the CLI:
+
+```sh
+gh workflow run publish-r2.yml --repo Ayuilos/Miffan --ref master -f release_tag=3.0.5
+```
+
+## Tests
+
+Requires Node.js 24. Unit tests need no credentials, network, APK build or Android SDK:
+
+```sh
+node --test .github/scripts/publish_r2.test.mjs
+```
+
+For a read-only check of the real GitHub release (requires logged-in `gh`, downloads APK/checksum but performs no R2 writes):
+
+```sh
+node .github/scripts/publish_r2.mjs --verify-source
+```
+
+## Official references
+
+- [R2 authentication and bucket-level permissions](https://developers.cloudflare.com/r2/api/tokens/)
+- [R2 S3 API conditional writes](https://developers.cloudflare.com/r2/api/s3/api/)
+- [GitHub release events](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release)
+- [Triggering a workflow from another workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow)

--- a/.github/scripts/publish_r2.mjs
+++ b/.github/scripts/publish_r2.mjs
@@ -1,0 +1,262 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream, mkdtempSync, readFileSync, statSync, writeFileSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const REPO = 'Ayuilos/Miffan';
+export const BUCKET = 'miffan-releases';
+export const ORIGIN = 'https://downloads.ayuilos.me';
+const ENDPOINT = 'https://c2df10005f1eb0cb71b0e7b4d089cdb3.r2.cloudflarestorage.com';
+const IMMUTABLE = 'public, max-age=31536000, immutable';
+
+export function validTag(tag) {
+  return typeof tag === 'string' && tag.length <= 64 &&
+    /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(tag);
+}
+
+export function parseManifest(value) {
+  if (!value || !validTag(value.version) || value.architecture !== 'arm64-v8a' ||
+      typeof value.publishedAt !== 'string' || !Number.isFinite(Date.parse(value.publishedAt)) ||
+      !Number.isSafeInteger(value.size) || value.size <= 0 || value.size > 512_000_000 ||
+      typeof value.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(value.sha256)) {
+    throw new Error('Invalid stable release manifest.');
+  }
+  const fileName = 'Miffan-' + value.version.replace(/^v/, '') + '-arm64-v8a.apk';
+  const downloadUrl = ORIGIN + '/releases/' + value.version + '/' + fileName;
+  const releaseUrl = 'https://github.com/' + REPO + '/releases/tag/' + value.version;
+  if (value.fileName !== fileName || value.downloadUrl !== downloadUrl ||
+      value.checksumUrl !== downloadUrl + '.sha256' || value.releaseUrl !== releaseUrl) {
+    throw new Error('Release manifest has an unexpected URL or filename.');
+  }
+  return {
+    version: value.version, publishedAt: value.publishedAt, architecture: 'arm64-v8a',
+    fileName, size: value.size, sha256: value.sha256, downloadUrl,
+    checksumUrl: downloadUrl + '.sha256', releaseUrl,
+  };
+}
+
+export function releaseFromGitHub(data) {
+  if (data?.draft !== false || data?.prerelease !== false || !validTag(data.tag_name)) {
+    throw new Error('Only published stable SemVer releases may be mirrored.');
+  }
+  const fileName = 'Miffan-' + data.tag_name.replace(/^v/, '') + '-arm64-v8a.apk';
+  const assets = Array.isArray(data.assets) ? data.assets : [];
+  const apks = assets.filter(asset => asset.name === fileName);
+  const checksums = assets.filter(asset => asset.name === fileName + '.sha256');
+  if (apks.length !== 1 || checksums.length !== 1 || !/^sha256:[a-f0-9]{64}$/.test(apks[0].digest ?? '')) {
+    throw new Error('Expected exactly one ARM64 APK with a GitHub digest and its checksum file.');
+  }
+  const downloadUrl = ORIGIN + '/releases/' + data.tag_name + '/' + fileName;
+  return parseManifest({
+    version: data.tag_name, publishedAt: data.published_at, architecture: 'arm64-v8a',
+    fileName, size: apks[0].size, sha256: apks[0].digest.slice(7),
+    downloadUrl, checksumUrl: downloadUrl + '.sha256',
+    releaseUrl: 'https://github.com/' + REPO + '/releases/tag/' + data.tag_name,
+  });
+}
+
+export async function fileHash(file) {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(file)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+export async function verifyFile(file, expected) {
+  if (statSync(file).size !== expected.size) throw new Error('File size mismatch: ' + file);
+  if (await fileHash(file) !== expected.sha256) throw new Error('SHA-256 mismatch: ' + file);
+}
+
+export function verifyChecksum(text, release) {
+  const fields = text.trim().split(/\s+/);
+  if (fields.length !== 2 || fields[0] !== release.sha256 ||
+      fields[1].replace(/^\*/, '') !== release.fileName) throw new Error('Published checksum file mismatch.');
+}
+
+export function compareVersions(left, right) {
+  if (!validTag(left) || !validTag(right)) throw new Error('Invalid version comparison.');
+  const a = left.replace(/^v/, '').split('.').map(BigInt);
+  const b = right.replace(/^v/, '').split('.').map(BigInt);
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] > b[i] ? 1 : -1;
+  return 0;
+}
+
+export function shouldPromote(current, next, githubLatestTag) {
+  if (current) {
+    if (compareVersions(current.version, next.version) === 0 && current.sha256 !== next.sha256) {
+      throw new Error('Refusing to replace the same version with different bytes.');
+    }
+    if (compareVersions(current.version, next.version) > 0 ||
+        Date.parse(current.publishedAt) > Date.parse(next.publishedAt)) return false;
+  }
+  return githubLatestTag === next.version;
+}
+
+function run(command, args) {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 300000,
+      maxBuffer: 4 * 1024 * 1024,
+      env: {
+        ...process.env, AWS_EC2_METADATA_DISABLED: 'true', AWS_PAGER: '',
+        AWS_REQUEST_CHECKSUM_CALCULATION: 'WHEN_REQUIRED',
+        AWS_RESPONSE_CHECKSUM_VALIDATION: 'WHEN_REQUIRED',
+      },
+    });
+  } catch (error) {
+    // No command arguments or environment variables are included in errors.
+    const stderr = String(error.stderr ?? '').trim();
+    throw new Error(command + ' failed: ' + (stderr || 'timeout or nonzero exit status'));
+  }
+}
+
+function githubRelease(tag) {
+  if (tag && !validTag(tag)) throw new Error('Unsupported release tag.');
+  return releaseFromGitHub(JSON.parse(run('gh', [
+    'api', 'repos/' + REPO + '/releases/' + (tag ? 'tags/' + tag : 'latest'),
+  ])));
+}
+
+function s3(operation, args) {
+  return JSON.parse(run('aws', ['s3api', operation, '--endpoint-url', ENDPOINT,
+    '--region', 'auto', '--no-cli-pager', '--output', 'json', '--bucket', BUCKET, ...args]) || '{}');
+}
+
+function getObject(key, file) {
+  try {
+    return s3('get-object', ['--key', key, file]);
+  } catch (error) {
+    if (/\(NoSuchKey\).*GetObject/.test(error.message)) return null;
+    throw error; // Never interpret auth failures or network errors as missing objects.
+  }
+}
+
+function putObject(key, file, metadata, condition) {
+  const args = ['--key', key, '--body', file, '--content-type', metadata.contentType,
+    '--cache-control', metadata.cacheControl, '--content-md5',
+    createHash('md5').update(readFileSync(file)).digest('base64')];
+  if (metadata.fileName) args.push('--content-disposition', 'attachment; filename="' + metadata.fileName + '"');
+  args.push(condition.etag ? '--if-match' : '--if-none-match', condition.etag ?? '*');
+  return s3('put-object', args);
+}
+
+export async function ensureImmutable(key, file, metadata, io) {
+  const expected = { size: statSync(file).size, sha256: await fileHash(file) };
+  const existing = await io.read(key);
+  if (existing) {
+    await verifyFile(existing.file, expected);
+    return; // No overwrites of any versioned object, including checksum and metadata.
+  }
+  await io.write(key, file, metadata, {});
+}
+
+function publicDownload(url, file) {
+  run('curl', ['--fail', '--silent', '--show-error', '--location', '--proto', '=https',
+    '--proto-redir', '=https', '--retry', '3', '--retry-all-errors', '--retry-delay', '2',
+    '--connect-timeout', '10', '--max-time', '240', '--output', file, url]);
+}
+
+// Dependency injection keeps failure and race tests independent of live credentials.
+export async function publishRelease(release, files, io) {
+  const prefix = 'releases/' + release.version + '/';
+  await verifyFile(files.apk, release);
+  verifyChecksum(readFileSync(files.checksum, 'utf8'), release);
+  await io.immutable(prefix + release.fileName, files.apk, {
+    contentType: 'application/vnd.android.package-archive', cacheControl: IMMUTABLE, fileName: release.fileName,
+  });
+  await io.immutable(prefix + release.fileName + '.sha256', files.checksum, {
+    contentType: 'text/plain; charset=utf-8', cacheControl: IMMUTABLE, fileName: release.fileName + '.sha256',
+  });
+  await io.verifyPublicApk(release);
+  await io.immutable(prefix + 'release.json', files.manifest, {
+    contentType: 'application/json; charset=utf-8', cacheControl: IMMUTABLE,
+  });
+
+  // Read the authoritative S3 object, not a possibly stale CDN cache.
+  const current = await io.readLatest();
+  const previous = current ? parseManifest(current.value) : null;
+  const latest = await io.githubLatest();
+  if (!shouldPromote(previous, release, latest.version)) {
+    return { promoted: false, message: 'Version mirrored; preserving the newer/current latest release.' };
+  }
+  if (JSON.stringify(previous) !== JSON.stringify(release)) {
+    // R2 rejects the write if another publisher changed the pointer after readLatest().
+    await io.writeLatest(files.manifest, current?.etag);
+  }
+  await io.verifyPublicManifest(release);
+  return { promoted: true, message: 'Public APK and latest.json verified.' };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length > 1 || (args.length === 1 && args[0] !== '--verify-source')) {
+    throw new Error('Usage: node .github/scripts/publish_r2.mjs [--verify-source]');
+  }
+  const verifyOnly = args[0] === '--verify-source';
+  if (!verifyOnly && (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY)) {
+    throw new Error('Configure MIFFAN_R2_ACCESS_KEY_ID and MIFFAN_R2_SECRET_ACCESS_KEY in GitHub Actions secrets.');
+  }
+  const release = githubRelease(process.env.RELEASE_TAG?.trim());
+  const work = mkdtempSync(join(tmpdir(), 'miffan-r2-publish-'));
+  console.log('Verifying release ' + release.version + '; working directory: ' + work);
+  for (const name of [release.fileName, release.fileName + '.sha256']) {
+    run('gh', ['release', 'download', release.version, '--repo', REPO, '--pattern', name, '--dir', work]);
+  }
+  const files = { apk: join(work, release.fileName), checksum: join(work, release.fileName + '.sha256'),
+    manifest: join(work, 'release.json') };
+  await verifyFile(files.apk, release);
+  verifyChecksum(readFileSync(files.checksum, 'utf8'), release);
+  writeFileSync(files.manifest, JSON.stringify(release, null, 2) + '\n');
+  if (verifyOnly) {
+    console.log('GitHub APK and checksum verified; no R2 writes performed.');
+    return;
+  }
+
+  let sequence = 0;
+  const io = {
+    async read(key) {
+      const file = join(work, 'remote-' + (++sequence));
+      const metadata = getObject(key, file);
+      return metadata ? { file, etag: metadata.ETag } : null;
+    },
+    async write(key, file, metadata, condition) { putObject(key, file, metadata, condition); },
+    async immutable(key, file, metadata) { await ensureImmutable(key, file, metadata, io); },
+    async verifyPublicApk(value) {
+      const file = join(work, 'public.apk');
+      publicDownload(value.downloadUrl + '?verify=' + Date.now(), file);
+      await verifyFile(file, value);
+    },
+    async readLatest() {
+      const current = await io.read('latest.json');
+      if (!current) return null;
+      if (!current.etag) throw new Error('R2 did not return an ETag for latest.json.');
+      return { value: JSON.parse(readFileSync(current.file, 'utf8')), etag: current.etag };
+    },
+    async githubLatest() { return githubRelease(); },
+    async writeLatest(file, etag) {
+      putObject('latest.json', file, {
+        contentType: 'application/json; charset=utf-8', cacheControl: 'no-cache, max-age=0, must-revalidate',
+      }, { etag });
+    },
+    async verifyPublicManifest(value) {
+      const file = join(work, 'public-latest.json');
+      publicDownload(ORIGIN + '/latest.json?verify=' + Date.now(), file);
+      if (JSON.stringify(parseManifest(JSON.parse(readFileSync(file, 'utf8')))) !== JSON.stringify(value)) {
+        throw new Error('Public latest.json does not match the published version.');
+      }
+    },
+  };
+  const result = await publishRelease(release, files, io);
+  console.log(result.message + '\n' + release.downloadUrl);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY,
+      '## R2 release mirror\n\n' + result.message + '\n\n- Version: ' + release.version +
+      '\n- APK: [' + release.fileName + '](' + release.downloadUrl + ')\n- SHA-256: ' + release.sha256 +
+      '\n- Website: https://miffan.ayuilos.me\n');
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch(error => { console.error(error.message); process.exitCode = 1; });
+}

--- a/.github/scripts/publish_r2.test.mjs
+++ b/.github/scripts/publish_r2.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  ORIGIN, validTag, parseManifest, releaseFromGitHub, compareVersions,
+  shouldPromote, verifyFile, verifyChecksum, ensureImmutable, publishRelease,
+} from './publish_r2.mjs';
+
+const bytes = Buffer.from('signed APK fixture');
+const digest = createHash('sha256').update(bytes).digest('hex');
+function github(version = '3.0.5') {
+  const name = 'Miffan-' + version.replace(/^v/, '') + '-arm64-v8a.apk';
+  return {
+    tag_name: version, published_at: '2026-08-28T08:21:48Z', draft: false, prerelease: false,
+    assets: [{ name, size: bytes.length, digest: 'sha256:' + digest }, { name: name + '.sha256' }],
+  };
+}
+const release = releaseFromGitHub(github());
+
+function fixture(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'r2-publisher-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const files = { apk: join(dir, 'app.apk'), checksum: join(dir, 'app.sha256'), manifest: join(dir, 'release.json') };
+  writeFileSync(files.apk, bytes);
+  writeFileSync(files.checksum, digest + '  ' + release.fileName + '\n');
+  writeFileSync(files.manifest, JSON.stringify(release, null, 2) + '\n');
+  const events = [];
+  const old = releaseFromGitHub({ ...github('3.0.4'), published_at: '2026-08-27T00:00:00Z' });
+  const io = {
+    async immutable(key) { events.push(['immutable', key]); },
+    async verifyPublicApk() { events.push(['verify-apk']); },
+    async readLatest() { return { value: old, etag: '"original-etag"' }; },
+    async githubLatest() { return release; },
+    async writeLatest(file, etag) {
+      events.push(['latest', etag]);
+      assert.deepEqual(JSON.parse(readFileSync(file, 'utf8')), release);
+    },
+    async verifyPublicManifest() { events.push(['verify-manifest']); },
+  };
+  return { dir, files, events, io };
+}
+
+test('accepts only stable, path-safe semantic versions', () => {
+  for (const value of ['3.0.5', 'v3.0.5', '0.1.0', '100.200.300']) assert.equal(validTag(value), true);
+  for (const value of ['', undefined, '3.0.5-rc.1', 'nightly', '3.0.5+build', '03.0.5',
+    '../3.0.5', '3.0.5\n', '3.0.5;touch /tmp/x', '9'.repeat(100) + '.0.0']) assert.equal(validTag(value), false);
+});
+
+test('maps a published ARM64 APK into the website manifest contract', () => {
+  assert.equal(release.downloadUrl, ORIGIN + '/releases/3.0.5/Miffan-3.0.5-arm64-v8a.apk');
+  assert.equal(release.checksumUrl, release.downloadUrl + '.sha256');
+  assert.deepEqual(parseManifest(release), release);
+  assert.equal(releaseFromGitHub(github('v3.0.5')).fileName, release.fileName);
+});
+
+test('rejects drafts, prereleases, missing/ambiguous files, invalid hashes and sizes', () => {
+  for (const change of [
+    { draft: true }, { prerelease: true }, { tag_name: '3.0.5-rc.1' },
+    { assets: [] }, { assets: [github().assets[0]] },
+    { assets: [...github().assets, github().assets[0]] },
+    { assets: [...github().assets, github().assets[1]] },
+    { assets: [{ ...github().assets[0], digest: undefined }, github().assets[1]] },
+    { assets: [{ ...github().assets[0], size: 512_000_001 }, github().assets[1]] },
+    { assets: [{ ...github().assets[0], size: -1 }, github().assets[1]] },
+  ]) assert.throws(() => releaseFromGitHub({ ...github(), ...change }));
+});
+
+test('rejects untrusted URLs and invalid manifest fields', () => {
+  for (const change of [
+    { downloadUrl: 'https://evil.example/app.apk' }, { checksumUrl: 'https://evil.example/hash' },
+    { releaseUrl: 'https://evil.example' }, { fileName: '../app.apk' },
+    { architecture: 'x86_64' }, { publishedAt: 'bad' }, { sha256: '0' }, { size: 0 }, { size: 1.5 },
+  ]) assert.throws(() => parseManifest({ ...release, ...change }));
+  for (const value of [null, undefined, {}, []]) assert.throws(() => parseManifest(value));
+});
+
+test('version ordering is semantic, not lexical or publication-date-only', () => {
+  assert.equal(compareVersions('3.0.10', '3.0.9'), 1);
+  assert.equal(compareVersions('v3.0.5', '3.0.5'), 0);
+  assert.equal(compareVersions('2.99.99', '3.0.0'), -1);
+  assert.equal(compareVersions('999999999999999999.0.0', '999999999999999998.0.0'), 1);
+  assert.equal(shouldPromote(null, release, release.version), true);
+  assert.equal(shouldPromote(null, release, '3.0.6'), false);
+  assert.equal(shouldPromote(releaseFromGitHub(github('3.0.6')), release, release.version), false);
+  assert.equal(shouldPromote({ ...release, publishedAt: '2026-08-29T00:00:00Z' }, release, release.version), false);
+  assert.throws(() => shouldPromote({ ...release, sha256: '0'.repeat(64) }, release, release.version), /different bytes/);
+});
+
+test('verifies exact APK size, SHA-256, and checksum filename', async t => {
+  const { files } = fixture(t);
+  await verifyFile(files.apk, release);
+  verifyChecksum(readFileSync(files.checksum, 'utf8'), release);
+  verifyChecksum(digest + ' *' + release.fileName + '\r\n', release);
+  await assert.rejects(verifyFile(files.apk, { ...release, size: release.size + 1 }), /size mismatch/);
+  writeFileSync(files.apk, Buffer.alloc(bytes.length));
+  await assert.rejects(verifyFile(files.apk, release), /SHA-256 mismatch/);
+  assert.throws(() => verifyChecksum(digest + ' other.apk', release), /checksum/);
+  assert.throws(() => verifyChecksum('0'.repeat(64) + ' ' + release.fileName, release), /checksum/);
+});
+
+test('immutable objects are retained if identical and rejected if changed', async t => {
+  const { dir, files } = fixture(t);
+  const remote = join(dir, 'remote.apk');
+  writeFileSync(remote, bytes);
+  let writes = 0;
+  const io = {
+    async read() { return { file: remote }; },
+    async write() { writes++; },
+  };
+  await ensureImmutable('release.apk', files.apk, {}, io);
+  assert.equal(writes, 0);
+  writeFileSync(remote, Buffer.alloc(bytes.length));
+  await assert.rejects(ensureImmutable('release.apk', files.apk, {}, io), /SHA-256 mismatch/);
+  assert.equal(writes, 0);
+  io.read = async () => null;
+  io.write = async (_key, _file, _metadata, condition) => { assert.deepEqual(condition, {}); writes++; };
+  await ensureImmutable('release.apk', files.apk, {}, io);
+  assert.equal(writes, 1);
+});
+
+test('publishes latest only after public APK verification and passes the original ETag', async t => {
+  const { files, events, io } = fixture(t);
+  assert.equal((await publishRelease(release, files, io)).promoted, true);
+  assert.deepEqual(events.map(event => event[0]),
+    ['immutable', 'immutable', 'verify-apk', 'immutable', 'latest', 'verify-manifest']);
+  assert.deepEqual(events[4], ['latest', '"original-etag"']);
+});
+
+test('failed public APK verification never changes the latest pointer', async t => {
+  const { files, events, io } = fixture(t);
+  io.verifyPublicApk = async () => { throw new Error('Public download failed'); };
+  await assert.rejects(publishRelease(release, files, io), /Public download failed/);
+  assert.equal(events.some(event => event[0] === 'latest'), false);
+});
+
+test('bad source APK fails before any R2 upload', async t => {
+  const { files, events, io } = fixture(t);
+  writeFileSync(files.apk, 'tampered');
+  await assert.rejects(publishRelease(release, files, io), /size mismatch/);
+  assert.deepEqual(events, []);
+});
+
+test('latest auth/read errors and malformed manifests fail closed', async t => {
+  const { files, events, io } = fixture(t);
+  io.readLatest = async () => { throw new Error('AccessDenied'); };
+  await assert.rejects(publishRelease(release, files, io), /AccessDenied/);
+  io.readLatest = async () => ({ value: {}, etag: '"etag"' });
+  await assert.rejects(publishRelease(release, files, io), /Invalid stable release manifest/);
+  assert.equal(events.some(event => event[0] === 'latest'), false);
+});
+
+test('a changed GitHub latest or a newer R2 version is never downgraded', async t => {
+  const { files, events, io } = fixture(t);
+  io.githubLatest = async () => releaseFromGitHub(github('3.0.6'));
+  assert.equal((await publishRelease(release, files, io)).promoted, false);
+  io.githubLatest = async () => release;
+  io.readLatest = async () => ({ value: releaseFromGitHub(github('3.0.6')), etag: '"newer"' });
+  assert.equal((await publishRelease(release, files, io)).promoted, false);
+  assert.equal(events.some(event => event[0] === 'latest'), false);
+});
+
+test('idempotent reruns verify downloads without rewriting latest', async t => {
+  const { files, events, io } = fixture(t);
+  io.readLatest = async () => ({ value: release, etag: '"same"' });
+  assert.equal((await publishRelease(release, files, io)).promoted, true);
+  assert.equal(events.some(event => event[0] === 'latest'), false);
+  assert.equal(events.at(-1)[0], 'verify-manifest');
+});
+
+test('conditional-write races fail without retrying an unconditional overwrite', async t => {
+  const { files, events, io } = fixture(t);
+  let attempts = 0;
+  io.writeLatest = async (_file, etag) => {
+    assert.equal(etag, '"original-etag"');
+    attempts++;
+    throw new Error('PreconditionFailed');
+  };
+  await assert.rejects(publishRelease(release, files, io), /PreconditionFailed/);
+  assert.equal(attempts, 1);
+  assert.equal(events.some(event => event[0] === 'verify-manifest'), false);
+});
+
+test('first publication uses create-only latest semantics', async t => {
+  const { files, events, io } = fixture(t);
+  io.readLatest = async () => null;
+  await publishRelease(release, files, io);
+  assert.deepEqual(events.find(event => event[0] === 'latest'), ['latest', undefined]);
+});

--- a/.github/workflows/publish-r2.yml
+++ b/.github/workflows/publish-r2.yml
@@ -1,0 +1,70 @@
+name: Publish APK to R2
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Stable release tag to retry (leave empty for latest)
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - '.github/scripts/publish_r2*'
+      - '.github/workflows/publish-r2.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: r2-publish-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'production' }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    if: github.event_name != 'release' || github.event.release.prerelease == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.ref || 'master' }}
+          persist-credentials: false
+          sparse-checkout: .github
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+      - name: Test release validation and failure safety
+        run: node --test .github/scripts/publish_r2.test.mjs
+
+  publish:
+    needs: verify
+    if: >-
+      github.repository == 'Ayuilos/Miffan' &&
+      ((github.event_name == 'release' && github.event.release.draft == false && github.event.release.prerelease == false) ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      # Never execute code from an arbitrary release tag with deployment credentials.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: master
+          persist-credentials: false
+          sparse-checkout: .github
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+      - name: Verify runner tools
+        run: |
+          gh --version
+          aws --version
+          curl --version
+      - name: Mirror and verify the published APK
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.MIFFAN_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MIFFAN_R2_SECRET_ACCESS_KEY }}
+        run: node .github/scripts/publish_r2.mjs


### PR DESCRIPTION
## Summary

- Automatically mirror published stable ARM64 APK releases to the existing `miffan-releases` R2 bucket and `downloads.ayuilos.me` domain.
- Update the website's `latest.json` only after source SHA-256 and public APK verification; preserve immutable versioned objects and prevent rollbacks/racing overwrites with conditional S3 writes.
- Add manual retry, 15 credential-free tests, pinned official Actions, and setup documentation.
- Keep existing production approvals, signing, draft-release preparation, and Android in-app updates unchanged.

## Validation

- `node --test .github/scripts/publish_r2.test.mjs` — 15 passed.
- `node --check .github/scripts/publish_r2.mjs` — passed.
- Actionlint v1.7.12 — passed.
- `node .github/scripts/publish_r2.mjs --verify-source` — downloaded and verified the real 3.0.5 APK and published checksum, without R2 writes.

## Activation still required

The repository does not yet have unattended R2 credentials. Create an **Object Read & Write** token restricted to **only `miffan-releases`**, then store its S3 credentials as:

- `MIFFAN_R2_ACCESS_KEY_ID`
- `MIFFAN_R2_SECRET_ACCESS_KEY`

Do not use a Global API Key or export the local Wrangler OAuth session. After merge and credential setup, dispatch `publish-r2.yml` on `master` for `3.0.5` and confirm the first real S3 run. The S3 credentialed integration has not yet been run.

Future releases automatically mirror after the reviewed draft is published as a stable GitHub Release. Drafts, nightly builds and prereleases are excluded.
