### PR TITLE
chore: release Miffan 3.0.6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "me.ayuilos.miffan.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 178008
-        versionName = "3.0.5"
+        versionCode = 178009
+        versionName = "3.0.6"
 
         buildConfigField("boolean", "FIREBASE_ENABLED", hasGoogleServicesConfig.toString())
 

--- a/docs/releases/3.0.6.md
+++ b/docs/releases/3.0.6.md
@@ -1,0 +1,29 @@
+# 3.0.6
+
+更新内容：
+
+### Miffan 自有改动
+
+- 新增官方下载源，并支持在「设置 → 偏好设置 → 网络」中配置可信的 HTTPS 下载目录；下载源不可用时自动回退到 GitHub。
+- 更新包下载遇到网络或 HTTP 错误时，可继续尝试其他来源的同一版本，离开设置页面后仍可重试；取消下载或存储空间问题不会触发换源，安装仍需手动确认。
+- 为按时间清理增加文件分类和路径检查，避免异常备份记录或外部链接导致误删其他文件。
+
+### 同步自 RikkaHub
+
+- 存储管理支持清理 7 天、14 天或 30 天前的文件，也可选择全部清理，并显示当前分类文件将被永久删除的提醒。
+- 修复仅包含工具调用的消息不显示操作按钮的问题。
+- 修正 HY4 的输入能力标记，不再误标为支持图片输入，保留工具调用和思考能力。
+
+Updates:
+
+### Miffan changes
+
+- Added an official download source and support for trusted HTTPS download directories under Settings → Preferences → Network, with automatic GitHub fallback when sources are unavailable.
+- Update downloads can retry the same version from another source after network or HTTP errors, even after leaving Settings. Cancellation and storage problems do not switch sources; installation still requires manual confirmation.
+- Added category and path checks to age-based cleanup to prevent malformed backup records or external links from causing unrelated files to be deleted.
+
+### Synced from RikkaHub
+
+- Storage management can now remove files older than 7, 14, or 30 days, or clear all files, with a warning that files in the current category will be permanently deleted.
+- Fixed missing action buttons on messages containing only tool calls.
+- Corrected HY4's input capabilities: image input is no longer advertised, while tool calling and reasoning remain available.

--- a/docs/upstream-sync/2026-08-28-3.0.6.md
+++ b/docs/upstream-sync/2026-08-28-3.0.6.md
@@ -28,12 +28,19 @@ The merge records the reviewed upstream ancestry but starts from the Miffan tree
 
 - Add category/path bounds to the new age-based cleanup, reject directories and links outside the selected category, and test boundaries, stale records and cross-category safety.
 - Remove two untracked, byte-identical build-plugin source copies under `build-logic/bin/main`; preserve `build-logic/src/main/kotlin` and ignore regenerated `/bin` output.
+- Cover official-source HTTP 403 challenge fallback to GitHub, and correct the old Android test package assertion to use the existing build-specific application ID.
 - Keep package identity, production signing, protected-environment approval, deep links, OAuth code, database schema, model API paths and dependency versions unchanged by the upstream sync.
 
 ## Verification
 
-- Full JVM tests, lint, debug/test APK build and focused Android acceptance: pending.
+- Final candidate: `3.0.6` / versionCode `178009`; bilingual notes are in `docs/releases/3.0.6.md`. Production signing, in-place upgrade acceptance of the signed candidate and publication remain pending explicit approval.
+- `./gradlew --offline test lint assembleDebug :app:assembleDebugAndroidTest --stacktrace`: passed after the version update. JVM reports contain 704 tests in 118 suites, with no failures, errors or skips. Debug artifact metadata matches `3.0.6` / `178009` and `me.ayuilos.miffan.app.debug`.
+- Android API 35 / arm64 / 16 KB emulator: all 25 test cases were verified. The final full run passed 24/25; the remaining floating-header screenshot hit a PixelCopy timeout and passed alone after the Gradle build finished (1/1). Earlier attempts also exposed the corrected package assertion, a transient screenshot failure and a system download job waiting for validated connectivity; these failures are not counted as clean full-suite passes.
+- Download acceptance uses a loopback HTTP server, exercising a permanent redirect, HTTP failure, persisted broadcast-driven source switching and successful completion through Android DownloadManager. The disposable emulator's external captive-portal probe was disabled and its virtual mobile network reconnected solely to satisfy the system's validated-network scheduling condition for this local test. No app network policy, real device or Cloudflare security setting was changed.
+- Four scoped-cleanup tests cover cutoff boundaries, other categories, missing records, directories and external links; all seven migration tests, legacy Chatbox import and existing mascot/header behavior are also covered. No live model generation or real OAuth flow was exercised.
+- Sync PR [18](https://github.com/Ayuilos/Miffan/pull/18) CI passed: [run 33183375300](https://github.com/Ayuilos/Miffan/actions/runs/33183375300). The separate version/notes release PR must also pass CI before a production build.
+- R2 publishing script: `node --test .github/scripts/publish_r2.test.mjs`, 15/15 passed.
 - R2 mirror workflow previously succeeded: run `33167127165`.
-- Preflight request to `https://downloads.ayuilos.me/latest.json` from the current network returned HTTP 403 with `cf-mitigated: challenge`, including with the Android updater request headers. This is not evidence that the manifest is missing or that all clients fail. Keep GitHub fallback covered and recheck public download availability before publication. No Cloudflare security setting was changed.
+- Initial preflight requests to `https://downloads.ayuilos.me/latest.json` returned HTTP 403 with `cf-mitigated: challenge`, including with Android updater headers. A later normal request on 2026-08-28 at 15:14 UTC returned HTTP 200. The manifest and checksum match published 3.0.5; the APK HEAD request returned HTTP 200 and the expected 40,466,226 bytes at 15:17 UTC. This checks metadata and reachability, not a new full APK digest verification. Retain the 403 fallback regression and recheck the new release's public artifacts after publication.
 
 References: [Google multi-tool documentation](https://ai.google.dev/gemini-api/docs/tool-combination), [R2 conditional object writes](https://developers.cloudflare.com/r2/api/s3/api/).


### PR DESCRIPTION
## Approved release

Prepare stable **3.0.6 / versionCode 178009** from the exact user-approved candidate `5c7a94d729036b784560ff903494742569a16a25`. The user explicitly confirmed the version and bilingual notes before this PR was opened.

- Version bump only: `3.0.5 / 178008` → `3.0.6 / 178009`.
- Bilingual release notes retain separate Miffan-owned and selected RikkaHub changes; the approved text is unchanged.
- Record completed local validation and the selective upstream audit. No additional product code, dependencies, OAuth migration, model API changes or signing changes are included beyond the approved sync PR #18.

## Validation

- Local `test lint assembleDebug :app:assembleDebugAndroidTest` passed for the final versioned candidate.
- 704 JVM tests passed; R2 publishing tests passed 15/15.
- Android API 35 arm64 / 16 KB: final whole-suite run passed 24/25. The remaining header screenshot hit a PixelCopy timeout and passed 1/1 when rerun alone after Gradle finished. All 25 cases have passing results, but the whole-suite run is not claimed to be clean.
- Scoped file cleanup, database migrations, legacy import, mascot/header behavior and system download redirect/background fallback were exercised.
- Official download manifest/checksum and APK address rechecks returned HTTP 200 and matched released 3.0.5. Initial HTTP 403 behavior remains covered by a fallback regression.

## Production gate

Do not merge until this PR's CI succeeds. Build only the resulting full merge SHA using the protected production workflow with explicit `3.0.6` and `178009` inputs. Preserve Ayuilos's production environment approval, the existing signing trust anchor and fixed package identity. Verify the signed arm64 APK's checksum, provenance and in-place upgrade before publishing the approved notes. Do not replace an existing tag or Release.
