### PR TITLE
release: Miffan 3.1.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "me.ayuilos.miffan.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 178010
-        versionName = "3.1.0"
+        versionCode = 178011
+        versionName = "3.1.1"
 
         buildConfigField("boolean", "FIREBASE_ENABLED", hasGoogleServicesConfig.toString())
 

--- a/app/src/main/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthService.kt
+++ b/app/src/main/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,12 +36,14 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.security.MessageDigest
 import java.security.SecureRandom
+import java.time.Instant
 import java.util.Base64
 import java.util.UUID
 
 private const val TAG = "OpenRouterAuth"
 private const val OPENROUTER_AUTH_URL = "https://openrouter.ai/auth"
 private const val OPENROUTER_KEY_EXCHANGE_URL = "https://openrouter.ai/api/v1/auth/keys"
+private const val OPENROUTER_KEY_INFO_URL = "https://openrouter.ai/api/v1/key"
 private const val OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 private const val OPENROUTER_CALLBACK_URL = "https://miffan.ayuilos.me/openrouter-callback.html"
 private const val OPENROUTER_FREE_MODEL = "openrouter/free"
@@ -56,6 +59,22 @@ sealed interface OpenRouterAuthState {
     data object Authorizing : OpenRouterAuthState
     data object Connected : OpenRouterAuthState
     data class Error(val message: String) : OpenRouterAuthState
+}
+
+sealed interface OpenRouterSavedKeyState {
+    data object Unchecked : OpenRouterSavedKeyState
+    data object Missing : OpenRouterSavedKeyState
+    data object Checking : OpenRouterSavedKeyState
+    data object Restoring : OpenRouterSavedKeyState
+    data class Valid(val expiresAt: Instant?) : OpenRouterSavedKeyState
+    data object Invalid : OpenRouterSavedKeyState
+    data object CheckFailed : OpenRouterSavedKeyState
+}
+
+internal sealed interface OpenRouterKeyValidationResult {
+    data class Valid(val expiresAt: Instant?) : OpenRouterKeyValidationResult
+    data object Invalid : OpenRouterKeyValidationResult
+    data object Unavailable : OpenRouterKeyValidationResult
 }
 
 internal data class OpenRouterPkce(
@@ -78,8 +97,90 @@ class OpenRouterAuthService(
     private val json = Json { ignoreUnknownKeys = true }
     private val _state = MutableStateFlow<OpenRouterAuthState>(OpenRouterAuthState.Idle)
     val state: StateFlow<OpenRouterAuthState> = _state.asStateFlow()
+    private val _savedKeyState = MutableStateFlow<OpenRouterSavedKeyState>(
+        OpenRouterSavedKeyState.Unchecked
+    )
+    val savedKeyState: StateFlow<OpenRouterSavedKeyState> = _savedKeyState.asStateFlow()
+    private var savedKeyJob: Job? = null
+
+    fun checkExistingKey() {
+        savedKeyJob?.cancel()
+        savedKeyJob = appScope.launch {
+            if (_state.value != OpenRouterAuthState.Authorizing) {
+                _state.value = OpenRouterAuthState.Idle
+            }
+            val settings = settingsStore.settingsFlow.first { current -> !current.init }
+            val apiKey = settings.openRouterApiKeyOrNull()
+            if (apiKey == null) {
+                _savedKeyState.value = OpenRouterSavedKeyState.Missing
+                return@launch
+            }
+
+            _savedKeyState.value = OpenRouterSavedKeyState.Checking
+            applySavedKeyValidation(validateOpenRouterKeySafely(apiKey))
+        }
+    }
+
+    fun restoreFreeModel() {
+        savedKeyJob?.cancel()
+        savedKeyJob = appScope.launch {
+            val settings = settingsStore.settingsFlow.first { current -> !current.init }
+            val apiKey = settings.openRouterApiKeyOrNull()
+            if (apiKey == null) {
+                _savedKeyState.value = OpenRouterSavedKeyState.Missing
+                return@launch
+            }
+
+            _savedKeyState.value = OpenRouterSavedKeyState.Restoring
+            when (val validation = validateOpenRouterKeySafely(apiKey)) {
+                is OpenRouterKeyValidationResult.Valid -> {
+                    val restored = settingsStore.updateIfCurrent(settings) { current ->
+                        current.withOpenRouterConnection(apiKey)
+                    }
+                    if (restored) {
+                        _savedKeyState.value = OpenRouterSavedKeyState.Valid(validation.expiresAt)
+                        _state.value = OpenRouterAuthState.Connected
+                    } else {
+                        checkExistingKey()
+                    }
+                }
+                OpenRouterKeyValidationResult.Invalid -> {
+                    _savedKeyState.value = OpenRouterSavedKeyState.Invalid
+                }
+                OpenRouterKeyValidationResult.Unavailable -> {
+                    _savedKeyState.value = OpenRouterSavedKeyState.CheckFailed
+                }
+            }
+        }
+    }
+
+    private suspend fun validateOpenRouterKeySafely(apiKey: String): OpenRouterKeyValidationResult =
+        runCatching { validateOpenRouterKey(apiKey) }
+            .onFailure { cause -> Log.w(TAG, "Unable to validate saved OpenRouter key", cause) }
+            .getOrDefault(OpenRouterKeyValidationResult.Unavailable)
+
+    private suspend fun validateOpenRouterKey(apiKey: String): OpenRouterKeyValidationResult =
+        withContext(Dispatchers.IO) {
+            httpClient.newCall(buildOpenRouterKeyValidationRequest(apiKey)).await().use { response ->
+                parseOpenRouterKeyValidation(
+                    code = response.code,
+                    body = response.body.string(),
+                )
+            }
+        }
+
+    private fun applySavedKeyValidation(result: OpenRouterKeyValidationResult) {
+        _savedKeyState.value = when (result) {
+            is OpenRouterKeyValidationResult.Valid -> {
+                OpenRouterSavedKeyState.Valid(result.expiresAt)
+            }
+            OpenRouterKeyValidationResult.Invalid -> OpenRouterSavedKeyState.Invalid
+            OpenRouterKeyValidationResult.Unavailable -> OpenRouterSavedKeyState.CheckFailed
+        }
+    }
 
     fun startAuthorization(languageTag: String? = null) {
+        savedKeyJob?.cancel()
         val state = UUID.randomUUID().toString()
         val pkce = generateOpenRouterPkce()
         pending.edit()
@@ -229,14 +330,59 @@ internal fun buildOpenRouterAuthorizationUrl(
         .toString()
 }
 
+internal fun buildOpenRouterKeyValidationRequest(apiKey: String): Request {
+    require(apiKey.isNotBlank()) { "OpenRouter API key cannot be blank" }
+    return Request.Builder()
+        .url(OPENROUTER_KEY_INFO_URL)
+        .header("Accept", "application/json")
+        .header("Authorization", "Bearer $apiKey")
+        .get()
+        .build()
+}
+
+internal fun parseOpenRouterKeyValidation(
+    code: Int,
+    body: String,
+    now: Instant = Instant.now(),
+): OpenRouterKeyValidationResult {
+    if (code == 401 || code == 403) return OpenRouterKeyValidationResult.Invalid
+    if (code !in 200..299) return OpenRouterKeyValidationResult.Unavailable
+
+    val expiresAt = runCatching {
+        val data = Json.parseToJsonElement(body).jsonObject["data"]?.jsonObject
+            ?: return OpenRouterKeyValidationResult.Unavailable
+        val rawExpiresAt = data["expires_at"]?.jsonPrimitive?.contentOrNull
+        rawExpiresAt?.let(Instant::parse)
+    }.getOrElse {
+        return OpenRouterKeyValidationResult.Unavailable
+    }
+    return if (expiresAt != null && !expiresAt.isAfter(now)) {
+        OpenRouterKeyValidationResult.Invalid
+    } else {
+        OpenRouterKeyValidationResult.Valid(expiresAt)
+    }
+}
+
+internal fun Settings.openRouterApiKeyOrNull(): String? = openRouterProvider()
+    ?.apiKey
+    ?.trim()
+    ?.takeIf(String::isNotBlank)
+
+private fun Settings.openRouterProvider(): ProviderSetting.OpenAI? {
+    val openRouterProviders = providers
+        .filterIsInstance<ProviderSetting.OpenAI>()
+        .filter { provider ->
+            provider.id == OPENROUTER_PROVIDER_ID ||
+                runCatching { provider.baseUrl.toHttpUrl().host == "openrouter.ai" }
+                    .getOrDefault(false)
+        }
+    return openRouterProviders.firstOrNull { it.id == OPENROUTER_PROVIDER_ID }
+        ?: openRouterProviders.firstOrNull()
+}
+
 internal fun Settings.withOpenRouterConnection(apiKey: String): Settings {
     require(apiKey.isNotBlank()) { "OpenRouter API key cannot be blank" }
-    val existing = providers
-        .filterIsInstance<ProviderSetting.OpenAI>()
-        .firstOrNull { provider ->
-            provider.id == OPENROUTER_PROVIDER_ID ||
-                runCatching { provider.baseUrl.toHttpUrl().host == "openrouter.ai" }.getOrDefault(false)
-        }
+    val existing = openRouterProvider()
     val freeModel = existing?.models
         ?.firstOrNull { it.modelId == OPENROUTER_FREE_MODEL }
         ?: Model(

--- a/app/src/main/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthService.kt
+++ b/app/src/main/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthService.kt
@@ -25,6 +25,7 @@ import me.ayuilos.miffan.data.datastore.OPENROUTER_PROVIDER_ID
 import me.ayuilos.miffan.data.datastore.Settings
 import me.ayuilos.miffan.data.datastore.SettingsStore
 import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ModelType
 import me.rerere.ai.provider.OpenAIAuthType
 import me.rerere.ai.provider.ProviderSetting
@@ -47,6 +48,10 @@ private const val OPENROUTER_KEY_INFO_URL = "https://openrouter.ai/api/v1/key"
 private const val OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 private const val OPENROUTER_CALLBACK_URL = "https://miffan.ayuilos.me/openrouter-callback.html"
 private const val OPENROUTER_FREE_MODEL = "openrouter/free"
+private val OPENROUTER_FREE_MODEL_ABILITIES = listOf(
+    ModelAbility.TOOL,
+    ModelAbility.REASONING,
+)
 private const val PENDING_PREFERENCES = "openrouter_oauth_pending"
 private const val PENDING_STATE = "state"
 private const val PENDING_VERIFIER = "verifier"
@@ -383,13 +388,16 @@ private fun Settings.openRouterProvider(): ProviderSetting.OpenAI? {
 internal fun Settings.withOpenRouterConnection(apiKey: String): Settings {
     require(apiKey.isNotBlank()) { "OpenRouter API key cannot be blank" }
     val existing = openRouterProvider()
-    val freeModel = existing?.models
+    val existingFreeModel = existing?.models
         ?.firstOrNull { it.modelId == OPENROUTER_FREE_MODEL }
-        ?: Model(
+    val freeModel = existingFreeModel?.copy(
+        abilities = (existingFreeModel.abilities + OPENROUTER_FREE_MODEL_ABILITIES).distinct(),
+    ) ?: Model(
             id = OPENROUTER_FREE_MODEL_ID,
             modelId = OPENROUTER_FREE_MODEL,
             displayName = "OpenRouter Free",
             type = ModelType.CHAT,
+            abilities = OPENROUTER_FREE_MODEL_ABILITIES,
         )
     val connectedProvider = (existing ?: ProviderSetting.OpenAI(
         id = OPENROUTER_PROVIDER_ID,

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/onboarding/OnboardingPage.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/onboarding/OnboardingPage.kt
@@ -1,5 +1,6 @@
 package me.ayuilos.miffan.ui.pages.onboarding
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,13 +25,15 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -53,6 +56,7 @@ import me.ayuilos.miffan.ui.components.ui.MiffanMascotState
 import me.ayuilos.miffan.ui.components.ui.miffanColors
 import me.ayuilos.miffan.ui.context.LocalNavController
 import me.ayuilos.miffan.ui.context.LocalSettings
+import me.ayuilos.miffan.ui.theme.LocalDarkMode
 import org.koin.compose.koinInject
 import kotlin.uuid.Uuid
 
@@ -65,6 +69,7 @@ fun OnboardingPage(
     val authState by authService.state.collectAsStateWithLifecycle()
     val savedKeyState by authService.savedKeyState.collectAsStateWithLifecycle()
     val languageTag = LocalConfiguration.current.locales[0].toLanguageTag()
+    var detailsVisible by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(settings.isNotConfigured()) {
         if (!settings.isNotConfigured()) {
@@ -90,9 +95,35 @@ fun OnboardingPage(
         savedKeyState == OpenRouterSavedKeyState.Checking
     val restoringSavedKey = savedKeyState == OpenRouterSavedKeyState.Restoring
     val busy = authorizing || checkingSavedKey || restoringSavedKey
+    val darkMode = LocalDarkMode.current
     val classicColors = MiffanPalette.CLASSIC.miffanColors()
-    val classicTextColor = lerp(classicColors.cueInk, Color.Black, 0.36f)
-    val classicActionColor = lerp(classicColors.bowl, Color.Black, 0.18f)
+    val classicContainerColor = if (darkMode) {
+        lerp(classicColors.bowl, Color.Black, 0.72f)
+    } else {
+        classicColors.cueSurface
+    }
+    val classicInsetColor = if (darkMode) {
+        lerp(classicColors.bowl, Color.Black, 0.52f)
+    } else {
+        classicColors.rice
+    }
+    val classicTextColor = if (darkMode) {
+        classicColors.rice
+    } else {
+        lerp(classicColors.cueInk, Color.Black, 0.36f)
+    }
+    val classicButtonColor = lerp(classicColors.bowl, Color.Black, 0.18f)
+    val classicLinkColor = if (darkMode) classicColors.rim else classicButtonColor
+    val classicBorderColor = classicColors.rim.copy(alpha = if (darkMode) 0.62f else 0.38f)
+    val connectionSummary = when (savedKeyState) {
+        OpenRouterSavedKeyState.Unchecked,
+        OpenRouterSavedKeyState.Checking -> R.string.onboarding_page_saved_key_checking
+        OpenRouterSavedKeyState.Restoring -> R.string.onboarding_page_saved_key_restoring
+        is OpenRouterSavedKeyState.Valid -> R.string.onboarding_page_saved_key_valid
+        OpenRouterSavedKeyState.Invalid -> R.string.onboarding_page_saved_key_invalid
+        OpenRouterSavedKeyState.CheckFailed -> R.string.onboarding_page_saved_key_check_failed
+        OpenRouterSavedKeyState.Missing -> R.string.onboarding_page_openrouter_brief
+    }
 
     Box(
         modifier = Modifier
@@ -104,128 +135,77 @@ fun OnboardingPage(
             modifier = Modifier
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp, vertical = 28.dp),
+                .padding(horizontal = 24.dp, vertical = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             MiffanMascot(
                 state = mascotState,
                 interactive = !busy,
-                modifier = Modifier.size(168.dp),
+                modifier = Modifier.size(124.dp),
             )
-            Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(8.dp))
             Text(
                 text = stringResource(R.string.onboarding_page_title),
                 style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.SemiBold,
                 textAlign = TextAlign.Center,
             )
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(6.dp))
             Text(
                 text = stringResource(R.string.onboarding_page_description),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )
-            Spacer(Modifier.height(28.dp))
+            Spacer(Modifier.height(20.dp))
 
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(28.dp),
                 colors = CardDefaults.cardColors(
-                    containerColor = classicColors.cueSurface,
+                    containerColor = classicContainerColor,
                     contentColor = classicTextColor,
                 ),
                 border = BorderStroke(
                     width = 1.dp,
-                    color = classicColors.rim.copy(alpha = 0.38f),
+                    color = classicBorderColor,
                 ),
             ) {
                 Column(
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier.padding(18.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = "OpenRouter",
-                                style = MaterialTheme.typography.titleSmallEmphasized,
-                                color = classicTextColor,
-                            )
-                            Text(
-                                text = "openrouter/free",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = classicTextColor.copy(alpha = 0.76f),
-                            )
-                        }
                         Surface(
                             shape = MaterialTheme.shapes.small,
-                            color = classicColors.rice,
+                            color = classicInsetColor,
                         ) {
                             Text(
-                                text = stringResource(R.string.onboarding_page_free_badge),
-                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+                                text = stringResource(R.string.onboarding_page_recommended_badge),
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = classicTextColor,
                                 fontWeight = FontWeight.Bold,
                             )
                         }
-                    }
-
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         Text(
-                            text = stringResource(R.string.onboarding_page_openrouter_about_title),
-                            style = MaterialTheme.typography.titleSmall,
+                            text = stringResource(R.string.onboarding_page_free_start_title),
+                            style = MaterialTheme.typography.titleLarge,
                             color = classicTextColor,
                             fontWeight = FontWeight.SemiBold,
-                        )
-                        Text(
-                            text = stringResource(R.string.onboarding_page_openrouter_about),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = classicTextColor.copy(alpha = 0.84f),
                         )
                     }
 
                     Text(
-                        text = stringResource(R.string.onboarding_page_free_limit),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = classicTextColor.copy(alpha = 0.76f),
+                        text = stringResource(connectionSummary),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = classicTextColor.copy(alpha = 0.84f),
                     )
-
-                    val savedKeyMessage = when (savedKeyState) {
-                        OpenRouterSavedKeyState.Unchecked,
-                        OpenRouterSavedKeyState.Checking -> {
-                            R.string.onboarding_page_saved_key_checking
-                        }
-                        OpenRouterSavedKeyState.Restoring -> {
-                            R.string.onboarding_page_saved_key_restoring
-                        }
-                        is OpenRouterSavedKeyState.Valid -> {
-                            R.string.onboarding_page_saved_key_valid
-                        }
-                        OpenRouterSavedKeyState.Invalid -> {
-                            R.string.onboarding_page_saved_key_invalid
-                        }
-                        OpenRouterSavedKeyState.CheckFailed -> {
-                            R.string.onboarding_page_saved_key_check_failed
-                        }
-                        OpenRouterSavedKeyState.Missing -> null
-                    }
-                    if (savedKeyMessage != null) {
-                        Surface(
-                            shape = MaterialTheme.shapes.medium,
-                            color = classicColors.rice,
-                        ) {
-                            Text(
-                                text = stringResource(savedKeyMessage),
-                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = classicTextColor,
-                            )
-                        }
-                    }
 
                     if (authState is OpenRouterAuthState.Error) {
                         Surface(
@@ -258,9 +238,9 @@ fun OnboardingPage(
                         },
                         enabled = !busy,
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = classicActionColor,
+                            containerColor = classicButtonColor,
                             contentColor = classicColors.rice,
-                            disabledContainerColor = classicActionColor.copy(alpha = 0.62f),
+                            disabledContainerColor = classicButtonColor.copy(alpha = 0.62f),
                             disabledContentColor = classicColors.rice.copy(alpha = 0.82f),
                         ),
                         modifier = Modifier
@@ -310,21 +290,65 @@ fun OnboardingPage(
                         TextButton(
                             onClick = authService::cancelAuthorization,
                             colors = ButtonDefaults.textButtonColors(
-                                contentColor = classicActionColor,
+                                contentColor = classicLinkColor,
                             ),
                             modifier = Modifier.align(Alignment.CenterHorizontally),
                         ) {
                             Text(stringResource(R.string.onboarding_page_cancel))
                         }
                     }
+                    TextButton(
+                        onClick = { detailsVisible = !detailsVisible },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = classicLinkColor,
+                        ),
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                    ) {
+                        Text(
+                            stringResource(
+                                if (detailsVisible) {
+                                    R.string.onboarding_page_details_hide
+                                } else {
+                                    R.string.onboarding_page_details_show
+                                }
+                            )
+                        )
+                    }
+                    AnimatedVisibility(visible = detailsVisible) {
+                        Surface(
+                            shape = MaterialTheme.shapes.medium,
+                            color = classicInsetColor,
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(14.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.onboarding_page_openrouter_about_title),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = classicTextColor,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                                Text(
+                                    text = stringResource(R.string.onboarding_page_openrouter_about),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = classicTextColor.copy(alpha = 0.84f),
+                                )
+                                Text(
+                                    text = stringResource(R.string.onboarding_page_free_limit),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = classicTextColor.copy(alpha = 0.76f),
+                                )
+                            }
+                        }
+                    }
                 }
             }
 
-            Spacer(Modifier.height(18.dp))
-            OutlinedButton(
+            Spacer(Modifier.height(8.dp))
+            TextButton(
                 onClick = { navController.navigate(Screen.SettingProvider) },
                 enabled = !authorizing && !restoringSavedKey,
-                modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.onboarding_page_manual_button))
             }

--- a/app/src/main/java/me/ayuilos/miffan/ui/pages/onboarding/OnboardingPage.kt
+++ b/app/src/main/java/me/ayuilos/miffan/ui/pages/onboarding/OnboardingPage.kt
@@ -1,5 +1,6 @@
 package me.ayuilos.miffan.ui.pages.onboarding
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,10 +16,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -30,6 +33,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -40,9 +45,12 @@ import me.ayuilos.miffan.R
 import me.ayuilos.miffan.Screen
 import me.ayuilos.miffan.data.ai.openrouter.OpenRouterAuthService
 import me.ayuilos.miffan.data.ai.openrouter.OpenRouterAuthState
+import me.ayuilos.miffan.data.ai.openrouter.OpenRouterSavedKeyState
 import me.ayuilos.miffan.data.datastore.isNotConfigured
+import me.ayuilos.miffan.data.model.MiffanPalette
 import me.ayuilos.miffan.ui.components.ui.MiffanMascot
 import me.ayuilos.miffan.ui.components.ui.MiffanMascotState
+import me.ayuilos.miffan.ui.components.ui.miffanColors
 import me.ayuilos.miffan.ui.context.LocalNavController
 import me.ayuilos.miffan.ui.context.LocalSettings
 import org.koin.compose.koinInject
@@ -55,21 +63,36 @@ fun OnboardingPage(
     val navController = LocalNavController.current
     val settings = LocalSettings.current
     val authState by authService.state.collectAsStateWithLifecycle()
+    val savedKeyState by authService.savedKeyState.collectAsStateWithLifecycle()
     val languageTag = LocalConfiguration.current.locales[0].toLanguageTag()
 
     LaunchedEffect(settings.isNotConfigured()) {
         if (!settings.isNotConfigured()) {
             navController.clearAndNavigate(Screen.Chat(Uuid.random().toString()))
+        } else {
+            authService.checkExistingKey()
         }
     }
 
-    val mascotState = when (authState) {
-        OpenRouterAuthState.Idle -> MiffanMascotState.Idle
-        OpenRouterAuthState.Authorizing -> MiffanMascotState.Thinking
-        OpenRouterAuthState.Connected -> MiffanMascotState.Happy
-        is OpenRouterAuthState.Error -> MiffanMascotState.Error
+    val mascotState = when {
+        authState is OpenRouterAuthState.Error ||
+            savedKeyState == OpenRouterSavedKeyState.CheckFailed -> MiffanMascotState.Error
+        authState == OpenRouterAuthState.Authorizing ||
+            savedKeyState == OpenRouterSavedKeyState.Unchecked ||
+            savedKeyState == OpenRouterSavedKeyState.Checking ||
+            savedKeyState == OpenRouterSavedKeyState.Restoring -> MiffanMascotState.Thinking
+        authState == OpenRouterAuthState.Connected ||
+            savedKeyState is OpenRouterSavedKeyState.Valid -> MiffanMascotState.Happy
+        else -> MiffanMascotState.Idle
     }
     val authorizing = authState == OpenRouterAuthState.Authorizing
+    val checkingSavedKey = savedKeyState == OpenRouterSavedKeyState.Unchecked ||
+        savedKeyState == OpenRouterSavedKeyState.Checking
+    val restoringSavedKey = savedKeyState == OpenRouterSavedKeyState.Restoring
+    val busy = authorizing || checkingSavedKey || restoringSavedKey
+    val classicColors = MiffanPalette.CLASSIC.miffanColors()
+    val classicTextColor = lerp(classicColors.cueInk, Color.Black, 0.36f)
+    val classicActionColor = lerp(classicColors.bowl, Color.Black, 0.18f)
 
     Box(
         modifier = Modifier
@@ -86,7 +109,7 @@ fun OnboardingPage(
         ) {
             MiffanMascot(
                 state = mascotState,
-                interactive = !authorizing,
+                interactive = !busy,
                 modifier = Modifier.size(168.dp),
             )
             Spacer(Modifier.height(12.dp))
@@ -105,15 +128,21 @@ fun OnboardingPage(
             )
             Spacer(Modifier.height(28.dp))
 
-            Surface(
+            Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(28.dp),
-                color = MaterialTheme.colorScheme.surfaceContainer,
-                tonalElevation = 2.dp,
+                colors = CardDefaults.cardColors(
+                    containerColor = classicColors.cueSurface,
+                    contentColor = classicTextColor,
+                ),
+                border = BorderStroke(
+                    width = 1.dp,
+                    color = classicColors.rim.copy(alpha = 0.38f),
+                ),
             ) {
                 Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -122,34 +151,81 @@ fun OnboardingPage(
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = "OpenRouter",
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.SemiBold,
+                                style = MaterialTheme.typography.titleSmallEmphasized,
+                                color = classicTextColor,
                             )
                             Text(
                                 text = "openrouter/free",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = classicTextColor.copy(alpha = 0.76f),
                             )
                         }
                         Surface(
-                            shape = CircleShape,
-                            color = MaterialTheme.colorScheme.primaryContainer,
+                            shape = MaterialTheme.shapes.small,
+                            color = classicColors.rice,
                         ) {
                             Text(
                                 text = stringResource(R.string.onboarding_page_free_badge),
                                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
                                 style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                color = classicTextColor,
                                 fontWeight = FontWeight.Bold,
                             )
                         }
                     }
 
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = stringResource(R.string.onboarding_page_openrouter_about_title),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = classicTextColor,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = stringResource(R.string.onboarding_page_openrouter_about),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = classicTextColor.copy(alpha = 0.84f),
+                        )
+                    }
+
                     Text(
                         text = stringResource(R.string.onboarding_page_free_limit),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = classicTextColor.copy(alpha = 0.76f),
                     )
+
+                    val savedKeyMessage = when (savedKeyState) {
+                        OpenRouterSavedKeyState.Unchecked,
+                        OpenRouterSavedKeyState.Checking -> {
+                            R.string.onboarding_page_saved_key_checking
+                        }
+                        OpenRouterSavedKeyState.Restoring -> {
+                            R.string.onboarding_page_saved_key_restoring
+                        }
+                        is OpenRouterSavedKeyState.Valid -> {
+                            R.string.onboarding_page_saved_key_valid
+                        }
+                        OpenRouterSavedKeyState.Invalid -> {
+                            R.string.onboarding_page_saved_key_invalid
+                        }
+                        OpenRouterSavedKeyState.CheckFailed -> {
+                            R.string.onboarding_page_saved_key_check_failed
+                        }
+                        OpenRouterSavedKeyState.Missing -> null
+                    }
+                    if (savedKeyMessage != null) {
+                        Surface(
+                            shape = MaterialTheme.shapes.medium,
+                            color = classicColors.rice,
+                        ) {
+                            Text(
+                                text = stringResource(savedKeyMessage),
+                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = classicTextColor,
+                            )
+                        }
+                    }
 
                     if (authState is OpenRouterAuthState.Error) {
                         Surface(
@@ -173,15 +249,28 @@ fun OnboardingPage(
                     }
 
                     Button(
-                        onClick = { authService.startAuthorization(languageTag) },
-                        enabled = !authorizing,
+                        onClick = {
+                            when (savedKeyState) {
+                                is OpenRouterSavedKeyState.Valid -> authService.restoreFreeModel()
+                                OpenRouterSavedKeyState.CheckFailed -> authService.checkExistingKey()
+                                else -> authService.startAuthorization(languageTag)
+                            }
+                        },
+                        enabled = !busy,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = classicActionColor,
+                            contentColor = classicColors.rice,
+                            disabledContainerColor = classicActionColor.copy(alpha = 0.62f),
+                            disabledContentColor = classicColors.rice.copy(alpha = 0.82f),
+                        ),
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(52.dp),
                     ) {
-                        if (authorizing) {
+                        if (busy) {
                             CircularProgressIndicator(
                                 modifier = Modifier.size(18.dp),
+                                color = classicColors.rice,
                                 strokeWidth = 2.dp,
                             )
                             Spacer(Modifier.width(10.dp))
@@ -189,14 +278,40 @@ fun OnboardingPage(
                         Text(
                             when {
                                 authorizing -> stringResource(R.string.onboarding_page_openrouter_connecting)
+                                checkingSavedKey -> stringResource(R.string.onboarding_page_saved_key_checking_button)
+                                restoringSavedKey -> stringResource(R.string.onboarding_page_saved_key_restoring_button)
+                                savedKeyState is OpenRouterSavedKeyState.Valid -> {
+                                    stringResource(R.string.onboarding_page_restore_free_model_button)
+                                }
+                                savedKeyState == OpenRouterSavedKeyState.CheckFailed -> {
+                                    stringResource(R.string.onboarding_page_verify_saved_key_button)
+                                }
+                                savedKeyState == OpenRouterSavedKeyState.Invalid -> {
+                                    stringResource(R.string.onboarding_page_reconnect_openrouter_button)
+                                }
                                 authState is OpenRouterAuthState.Error -> stringResource(R.string.onboarding_page_retry)
                                 else -> stringResource(R.string.onboarding_page_openrouter_button)
                             }
                         )
                     }
+                    if (
+                        savedKeyState == OpenRouterSavedKeyState.Missing ||
+                        savedKeyState == OpenRouterSavedKeyState.Invalid
+                    ) {
+                        Text(
+                            text = stringResource(R.string.onboarding_page_privacy),
+                            modifier = Modifier.fillMaxWidth(),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = classicTextColor.copy(alpha = 0.76f),
+                            textAlign = TextAlign.Center,
+                        )
+                    }
                     if (authorizing) {
                         TextButton(
                             onClick = authService::cancelAuthorization,
+                            colors = ButtonDefaults.textButtonColors(
+                                contentColor = classicActionColor,
+                            ),
                             modifier = Modifier.align(Alignment.CenterHorizontally),
                         ) {
                             Text(stringResource(R.string.onboarding_page_cancel))
@@ -208,18 +323,11 @@ fun OnboardingPage(
             Spacer(Modifier.height(18.dp))
             OutlinedButton(
                 onClick = { navController.navigate(Screen.SettingProvider) },
-                enabled = !authorizing,
+                enabled = !authorizing && !restoringSavedKey,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource(R.string.onboarding_page_manual_button))
             }
-            Spacer(Modifier.height(16.dp))
-            Text(
-                text = stringResource(R.string.onboarding_page_privacy),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-            )
         }
     }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1365,4 +1365,16 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="onboarding_page_free_limit">OpenRouterの無料モデルルーターを使用します。利用可能なモデル、速度、1日の上限は変更される場合があります。</string>
   <string name="onboarding_page_error_title">接続できませんでした</string>
   <string name="onboarding_page_retry">再試行</string>
+  <string name="onboarding_page_openrouter_about_title">OpenRouterを選ぶ理由</string>
+  <string name="onboarding_page_openrouter_about">OpenRouterは独立運営の第三者AIモデル集約プラットフォームであり、Miffanとの資本・提携関係はありません。多くの主要モデルと無料モデルルーターを利用できるため、すぐに始めるための選択肢として案内しています。プロバイダーはいつでも変更できます。</string>
+  <string name="onboarding_page_saved_key_checking">保存済みの OpenRouter 接続を確認しています…</string>
+  <string name="onboarding_page_saved_key_restoring">保存済みの接続は有効です。無料モデルを復元しています…</string>
+  <string name="onboarding_page_saved_key_valid">保存済みの OpenRouter 接続は引き続き有効です。再ログインせずに無料モデルを復元できます。</string>
+  <string name="onboarding_page_saved_key_invalid">保存済みの OpenRouter 接続は期限切れか、無効になっています。再接続して続行してください。</string>
+  <string name="onboarding_page_saved_key_check_failed">保存済みの OpenRouter 接続を確認できませんでした。ネットワークを確認して、もう一度お試しください。</string>
+  <string name="onboarding_page_saved_key_checking_button">接続を確認しています…</string>
+  <string name="onboarding_page_saved_key_restoring_button">無料モデルを復元しています…</string>
+  <string name="onboarding_page_restore_free_model_button">無料モデルを復元</string>
+  <string name="onboarding_page_verify_saved_key_button">もう一度確認</string>
+  <string name="onboarding_page_reconnect_openrouter_button">OpenRouter に再接続</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1354,14 +1354,14 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="setting_files_page_clean_all">すべてのファイル</string>
   <string name="setting_files_page_clean_older_than_days">%1$d日以上前</string>
   <string name="setting_files_page_clean_range_description">完全に削除するファイルを選択してください。この操作は元に戻せません。</string>
-  <string name="onboarding_page_title">1分でチャットを始める</string>
-  <string name="onboarding_page_description">今すぐ無料モデルに接続できます。プロバイダーとモデルはいつでも変更できます。</string>
+  <string name="onboarding_page_title">Miffan へようこそ</string>
+  <string name="onboarding_page_description">API がわからなくても大丈夫です。まずは無料モデルで始め、いつでも変更できます。</string>
   <string name="onboarding_page_free_badge">無料で始める</string>
-  <string name="onboarding_page_openrouter_button">OpenRouterに接続</string>
+  <string name="onboarding_page_openrouter_button">無料でチャットを始める</string>
   <string name="onboarding_page_openrouter_connecting">OpenRouterを待機中…</string>
   <string name="onboarding_page_cancel">キャンセル</string>
-  <string name="onboarding_page_manual_button">別のプロバイダーを設定</string>
-  <string name="onboarding_page_privacy">次に、安全なOpenRouterページを開いてログインと承認を行います。Miffanがパスワードを取得することはありません。</string>
+  <string name="onboarding_page_manual_button">別のプロバイダーを使用</string>
+  <string name="onboarding_page_privacy">OpenRouter のログイン画面が開きます。Miffan がパスワードを受け取ることはありません。</string>
   <string name="onboarding_page_free_limit">OpenRouterの無料モデルルーターを使用します。利用可能なモデル、速度、1日の上限は変更される場合があります。</string>
   <string name="onboarding_page_error_title">接続できませんでした</string>
   <string name="onboarding_page_retry">再試行</string>
@@ -1377,4 +1377,9 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="onboarding_page_restore_free_model_button">無料モデルを復元</string>
   <string name="onboarding_page_verify_saved_key_button">もう一度確認</string>
   <string name="onboarding_page_reconnect_openrouter_button">OpenRouter に再接続</string>
+  <string name="onboarding_page_recommended_badge">おすすめ</string>
+  <string name="onboarding_page_free_start_title">無料で始める</string>
+  <string name="onboarding_page_openrouter_brief">Miffan とは独立した第三者サービス OpenRouter が提供します。API キーを手動で入力する必要はありません。</string>
+  <string name="onboarding_page_details_show">OpenRouter と無料枠について</string>
+  <string name="onboarding_page_details_hide">詳細を閉じる</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1354,14 +1354,14 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="setting_files_page_clean_all">모든 파일</string>
   <string name="setting_files_page_clean_older_than_days">%1$d일 이상 지난 파일</string>
   <string name="setting_files_page_clean_range_description">영구적으로 삭제할 파일을 선택하세요. 이 작업은 되돌릴 수 없습니다.</string>
-  <string name="onboarding_page_title">1분 만에 채팅 시작</string>
-  <string name="onboarding_page_description">지금 무료 모델을 연결하세요. 제공업체와 모델은 언제든지 변경할 수 있습니다.</string>
+  <string name="onboarding_page_title">Miffan에 오신 것을 환영합니다</string>
+  <string name="onboarding_page_description">API를 몰라도 괜찮습니다. 먼저 무료 모델로 시작하고 언제든 변경할 수 있습니다.</string>
   <string name="onboarding_page_free_badge">무료로 시작</string>
-  <string name="onboarding_page_openrouter_button">OpenRouter 연결</string>
+  <string name="onboarding_page_openrouter_button">무료로 채팅 시작</string>
   <string name="onboarding_page_openrouter_connecting">OpenRouter 응답을 기다리는 중…</string>
   <string name="onboarding_page_cancel">취소</string>
-  <string name="onboarding_page_manual_button">다른 제공업체 설정</string>
-  <string name="onboarding_page_privacy">안전한 OpenRouter 페이지를 열어 로그인 및 승인을 진행합니다. Miffan은 비밀번호를 받지 않습니다.</string>
+  <string name="onboarding_page_manual_button">다른 제공자 사용</string>
+  <string name="onboarding_page_privacy">로그인을 위해 OpenRouter가 열립니다. Miffan은 비밀번호를 받지 않습니다.</string>
   <string name="onboarding_page_free_limit">OpenRouter 무료 모델 라우터를 사용합니다. 사용 가능한 모델, 속도 및 일일 한도는 달라질 수 있습니다.</string>
   <string name="onboarding_page_error_title">연결할 수 없음</string>
   <string name="onboarding_page_retry">다시 시도</string>
@@ -1377,4 +1377,9 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="onboarding_page_restore_free_model_button">무료 모델 복원</string>
   <string name="onboarding_page_verify_saved_key_button">다시 확인</string>
   <string name="onboarding_page_reconnect_openrouter_button">OpenRouter 다시 연결</string>
+  <string name="onboarding_page_recommended_badge">추천</string>
+  <string name="onboarding_page_free_start_title">무료로 시작</string>
+  <string name="onboarding_page_openrouter_brief">Miffan과 독립적으로 운영되는 타사 OpenRouter에서 제공합니다. API Key를 직접 입력할 필요가 없습니다.</string>
+  <string name="onboarding_page_details_show">OpenRouter와 무료 한도 알아보기</string>
+  <string name="onboarding_page_details_hide">세부 정보 닫기</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1365,4 +1365,16 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="onboarding_page_free_limit">OpenRouter 무료 모델 라우터를 사용합니다. 사용 가능한 모델, 속도 및 일일 한도는 달라질 수 있습니다.</string>
   <string name="onboarding_page_error_title">연결할 수 없음</string>
   <string name="onboarding_page_retry">다시 시도</string>
+  <string name="onboarding_page_openrouter_about_title">OpenRouter를 선택한 이유</string>
+  <string name="onboarding_page_openrouter_about">OpenRouter는 독립적으로 운영되는 타사 AI 모델 통합 플랫폼이며 Miffan과 제휴 또는 소속 관계가 없습니다. 다양한 주요 모델과 무료 모델 라우터를 제공하기 때문에 빠른 시작 옵션으로 안내합니다. 제공업체는 언제든지 변경할 수 있습니다.</string>
+  <string name="onboarding_page_saved_key_checking">저장된 OpenRouter 연결을 확인하는 중…</string>
+  <string name="onboarding_page_saved_key_restoring">저장된 연결이 아직 유효합니다. 무료 모델을 복원하는 중…</string>
+  <string name="onboarding_page_saved_key_valid">저장된 OpenRouter 연결이 아직 유효합니다. 다시 로그인하지 않고 무료 모델을 복원할 수 있습니다.</string>
+  <string name="onboarding_page_saved_key_invalid">저장된 OpenRouter 연결이 만료되었거나 더 이상 유효하지 않습니다. 다시 연결하여 계속하세요.</string>
+  <string name="onboarding_page_saved_key_check_failed">저장된 OpenRouter 연결을 확인할 수 없습니다. 네트워크를 확인하고 다시 시도하세요.</string>
+  <string name="onboarding_page_saved_key_checking_button">연결 확인 중…</string>
+  <string name="onboarding_page_saved_key_restoring_button">무료 모델 복원 중…</string>
+  <string name="onboarding_page_restore_free_model_button">무료 모델 복원</string>
+  <string name="onboarding_page_verify_saved_key_button">다시 확인</string>
+  <string name="onboarding_page_reconnect_openrouter_button">OpenRouter 다시 연결</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1365,4 +1365,16 @@
   <string name="onboarding_page_free_limit">Используется бесплатный маршрутизатор моделей OpenRouter. Доступные модели, скорость и дневные лимиты могут меняться.</string>
   <string name="onboarding_page_error_title">Не удалось подключиться</string>
   <string name="onboarding_page_retry">Повторить</string>
+  <string name="onboarding_page_openrouter_about_title">Почему OpenRouter?</string>
+  <string name="onboarding_page_openrouter_about">OpenRouter — независимая сторонняя платформа-агрегатор моделей ИИ, не связанная с Miffan и не являющаяся её партнёром. Мы предлагаем её для быстрого старта, поскольку она объединяет множество популярных моделей и предоставляет бесплатный маршрутизатор. Поставщика можно сменить в любое время.</string>
+  <string name="onboarding_page_saved_key_checking">Проверяем сохранённое подключение OpenRouter…</string>
+  <string name="onboarding_page_saved_key_restoring">Сохранённое подключение всё ещё действительно. Восстанавливаем бесплатную модель…</string>
+  <string name="onboarding_page_saved_key_valid">Сохранённое подключение OpenRouter всё ещё действительно. Бесплатную модель можно восстановить без повторного входа.</string>
+  <string name="onboarding_page_saved_key_invalid">Сохранённое подключение OpenRouter истекло или больше недействительно. Подключитесь снова, чтобы продолжить.</string>
+  <string name="onboarding_page_saved_key_check_failed">Не удалось проверить сохранённое подключение OpenRouter. Проверьте сеть и повторите попытку.</string>
+  <string name="onboarding_page_saved_key_checking_button">Проверяем подключение…</string>
+  <string name="onboarding_page_saved_key_restoring_button">Восстанавливаем бесплатную модель…</string>
+  <string name="onboarding_page_restore_free_model_button">Восстановить бесплатную модель</string>
+  <string name="onboarding_page_verify_saved_key_button">Проверить снова</string>
+  <string name="onboarding_page_reconnect_openrouter_button">Повторно подключить OpenRouter</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1354,14 +1354,14 @@
   <string name="setting_files_page_clean_all">Все файлы</string>
   <string name="setting_files_page_clean_older_than_days">Старше %1$d дней</string>
   <string name="setting_files_page_clean_range_description">Выберите файлы для окончательного удаления. Это действие нельзя отменить.</string>
-  <string name="onboarding_page_title">Начните общение за минуту</string>
-  <string name="onboarding_page_description">Подключите бесплатную модель. Поставщика и модель можно изменить в любое время.</string>
+  <string name="onboarding_page_title">Добро пожаловать в Miffan</string>
+  <string name="onboarding_page_description">Необязательно разбираться в API. Начните с бесплатной модели — её всегда можно сменить.</string>
   <string name="onboarding_page_free_badge">НАЧАТЬ БЕСПЛАТНО</string>
-  <string name="onboarding_page_openrouter_button">Подключить OpenRouter</string>
+  <string name="onboarding_page_openrouter_button">Начать чат бесплатно</string>
   <string name="onboarding_page_openrouter_connecting">Ожидание OpenRouter…</string>
   <string name="onboarding_page_cancel">Отмена</string>
-  <string name="onboarding_page_manual_button">Настроить другого поставщика</string>
-  <string name="onboarding_page_privacy">Будет открыта защищённая страница OpenRouter для входа и подтверждения. Miffan не получает ваш пароль.</string>
+  <string name="onboarding_page_manual_button">Использовать другого провайдера</string>
+  <string name="onboarding_page_privacy">Для входа откроется OpenRouter. Miffan не получает ваш пароль.</string>
   <string name="onboarding_page_free_limit">Используется бесплатный маршрутизатор моделей OpenRouter. Доступные модели, скорость и дневные лимиты могут меняться.</string>
   <string name="onboarding_page_error_title">Не удалось подключиться</string>
   <string name="onboarding_page_retry">Повторить</string>
@@ -1377,4 +1377,9 @@
   <string name="onboarding_page_restore_free_model_button">Восстановить бесплатную модель</string>
   <string name="onboarding_page_verify_saved_key_button">Проверить снова</string>
   <string name="onboarding_page_reconnect_openrouter_button">Повторно подключить OpenRouter</string>
+  <string name="onboarding_page_recommended_badge">Рекомендуем</string>
+  <string name="onboarding_page_free_start_title">Начать бесплатно</string>
+  <string name="onboarding_page_openrouter_brief">Сервис предоставляется сторонней платформой OpenRouter, которая работает независимо от Miffan. Вводить API-ключ вручную не нужно.</string>
+  <string name="onboarding_page_details_show">Об OpenRouter и бесплатных лимитах</string>
+  <string name="onboarding_page_details_hide">Скрыть подробности</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1363,4 +1363,16 @@
   <string name="onboarding_page_free_limit">將使用 OpenRouter 免費模型路由；可用模型、速度和每日限額可能有所變化。</string>
   <string name="onboarding_page_error_title">連接失敗</string>
   <string name="onboarding_page_retry">重試</string>
+  <string name="onboarding_page_openrouter_about_title">為什麼選擇 OpenRouter？</string>
+  <string name="onboarding_page_openrouter_about">OpenRouter 是獨立營運的第三方 AI 模型聚合平台，與 Miffan 沒有隸屬或合作關係。我們將它作為快速開始選項，是因為它匯集了大量主流模型並提供免費模型路由；你也可以隨時改用其他服務商。</string>
+  <string name="onboarding_page_saved_key_checking">正在驗證已儲存的 OpenRouter 連線…</string>
+  <string name="onboarding_page_saved_key_restoring">已儲存的連線仍然有效，正在恢復免費模型…</string>
+  <string name="onboarding_page_saved_key_valid">已儲存的 OpenRouter 連線仍然有效，可以直接恢復免費模型，無需重新登入。</string>
+  <string name="onboarding_page_saved_key_invalid">已儲存的 OpenRouter 連線已過期或失效，請重新連線後繼續。</string>
+  <string name="onboarding_page_saved_key_check_failed">暫時無法驗證已儲存的 OpenRouter 連線，請檢查網路後重試。</string>
+  <string name="onboarding_page_saved_key_checking_button">正在驗證連線…</string>
+  <string name="onboarding_page_saved_key_restoring_button">正在恢復免費模型…</string>
+  <string name="onboarding_page_restore_free_model_button">恢復免費模型</string>
+  <string name="onboarding_page_verify_saved_key_button">重新驗證</string>
+  <string name="onboarding_page_reconnect_openrouter_button">重新連線 OpenRouter</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1352,14 +1352,14 @@
   <string name="setting_files_page_clean_all">所有檔案</string>
   <string name="setting_files_page_clean_older_than_days">%1$d 天前</string>
   <string name="setting_files_page_clean_range_description">選擇要永久刪除的檔案。此操作無法復原。</string>
-  <string name="onboarding_page_title">一分鐘開始聊天</string>
-  <string name="onboarding_page_description">立即連接免費模型，之後可隨時更換服務商和模型。</string>
+  <string name="onboarding_page_title">歡迎來到 Miffan</string>
+  <string name="onboarding_page_description">不懂 API 也沒關係，先用免費模型開始聊天，以後隨時可以更換。</string>
   <string name="onboarding_page_free_badge">免費開始</string>
-  <string name="onboarding_page_openrouter_button">連接 OpenRouter</string>
+  <string name="onboarding_page_openrouter_button">免費開始聊天</string>
   <string name="onboarding_page_openrouter_connecting">正在等待 OpenRouter…</string>
   <string name="onboarding_page_cancel">取消</string>
-  <string name="onboarding_page_manual_button">設定其他服務商</string>
-  <string name="onboarding_page_privacy">接下來會開啟安全的 OpenRouter 頁面進行登入與授權，Miffan 不會接觸你的密碼。</string>
+  <string name="onboarding_page_manual_button">使用其他服務商</string>
+  <string name="onboarding_page_privacy">將開啟 OpenRouter 完成登入；Miffan 不會取得你的密碼。</string>
   <string name="onboarding_page_free_limit">將使用 OpenRouter 免費模型路由；可用模型、速度和每日限額可能有所變化。</string>
   <string name="onboarding_page_error_title">連接失敗</string>
   <string name="onboarding_page_retry">重試</string>
@@ -1375,4 +1375,9 @@
   <string name="onboarding_page_restore_free_model_button">恢復免費模型</string>
   <string name="onboarding_page_verify_saved_key_button">重新驗證</string>
   <string name="onboarding_page_reconnect_openrouter_button">重新連線 OpenRouter</string>
+  <string name="onboarding_page_recommended_badge">推薦</string>
+  <string name="onboarding_page_free_start_title">免費開始</string>
+  <string name="onboarding_page_openrouter_brief">由獨立於 Miffan 的第三方 OpenRouter 提供，無需手動填寫 API Key。</string>
+  <string name="onboarding_page_details_show">瞭解 OpenRouter 和免費額度</string>
+  <string name="onboarding_page_details_hide">收起詳細說明</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -8,14 +8,14 @@
   <string name="about_page_website">官网</string>
   <string name="add">添加</string>
   <string name="app_name">Miffan</string>
-  <string name="onboarding_page_title">一分钟开始聊天</string>
-  <string name="onboarding_page_description">现在连接一个免费模型，以后随时可以更换服务商和模型。</string>
+  <string name="onboarding_page_title">欢迎来到 Miffan</string>
+  <string name="onboarding_page_description">不懂 API 也没关系，先用免费模型开始聊天，以后随时可以更换。</string>
   <string name="onboarding_page_free_badge">免费开始</string>
-  <string name="onboarding_page_openrouter_button">连接 OpenRouter</string>
+  <string name="onboarding_page_openrouter_button">免费开始聊天</string>
   <string name="onboarding_page_openrouter_connecting">正在等待 OpenRouter…</string>
   <string name="onboarding_page_cancel">取消</string>
-  <string name="onboarding_page_manual_button">设置其他服务商</string>
-  <string name="onboarding_page_privacy">接下来会打开安全的 OpenRouter 页面进行登录和授权，Miffan 不会接触你的密码。</string>
+  <string name="onboarding_page_manual_button">使用其他服务商</string>
+  <string name="onboarding_page_privacy">将打开 OpenRouter 完成登录；Miffan 不会获取你的密码。</string>
   <string name="onboarding_page_free_limit">将使用 OpenRouter 免费模型路由；可用模型、速度和每日限额可能变化。</string>
   <string name="onboarding_page_error_title">连接失败</string>
   <string name="onboarding_page_retry">重试</string>
@@ -1377,4 +1377,9 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="onboarding_page_restore_free_model_button">恢复免费模型</string>
   <string name="onboarding_page_verify_saved_key_button">重新验证</string>
   <string name="onboarding_page_reconnect_openrouter_button">重新连接 OpenRouter</string>
+  <string name="onboarding_page_recommended_badge">推荐</string>
+  <string name="onboarding_page_free_start_title">免费开始</string>
+  <string name="onboarding_page_openrouter_brief">由独立于 Miffan 的第三方 OpenRouter 提供，无需手动填写 API Key。</string>
+  <string name="onboarding_page_details_show">了解 OpenRouter 和免费额度</string>
+  <string name="onboarding_page_details_hide">收起详细说明</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1365,4 +1365,16 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="chat_generation_network_timeout">连接超时</string>
   <string name="chat_generation_network_unreachable">无法连接到服务器</string>
   <string name="chat_generation_network_disconnected">网络连接已断开</string>
+  <string name="onboarding_page_openrouter_about_title">为什么选择 OpenRouter？</string>
+  <string name="onboarding_page_openrouter_about">OpenRouter 是独立运营的第三方 AI 模型聚合平台，与 Miffan 没有隶属或合作关系。我们将它作为快速开始选项，是因为它汇集了大量主流模型并提供免费模型路由；你也可以随时改用其他服务商。</string>
+  <string name="onboarding_page_saved_key_checking">正在验证已保存的 OpenRouter 连接…</string>
+  <string name="onboarding_page_saved_key_restoring">已保存的连接仍然有效，正在恢复免费模型…</string>
+  <string name="onboarding_page_saved_key_valid">已保存的 OpenRouter 连接仍然有效，可以直接恢复免费模型，无需重新登录。</string>
+  <string name="onboarding_page_saved_key_invalid">已保存的 OpenRouter 连接已过期或失效，请重新连接后继续。</string>
+  <string name="onboarding_page_saved_key_check_failed">暂时无法验证已保存的 OpenRouter 连接，请检查网络后重试。</string>
+  <string name="onboarding_page_saved_key_checking_button">正在验证连接…</string>
+  <string name="onboarding_page_saved_key_restoring_button">正在恢复免费模型…</string>
+  <string name="onboarding_page_restore_free_model_button">恢复免费模型</string>
+  <string name="onboarding_page_verify_saved_key_button">重新验证</string>
+  <string name="onboarding_page_reconnect_openrouter_button">重新连接 OpenRouter</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1363,4 +1363,16 @@
   <string name="chat_generation_network_timeout">Connection timed out</string>
   <string name="chat_generation_network_unreachable">Unable to connect to server</string>
   <string name="chat_generation_network_disconnected">Network connection lost</string>
+  <string name="onboarding_page_openrouter_about_title">Why OpenRouter?</string>
+  <string name="onboarding_page_openrouter_about">OpenRouter is an independently operated third-party AI model aggregation platform and is not affiliated with or partnered with Miffan. We offer it as a quick-start option because it provides access to many popular models and a free model router. You can switch providers at any time.</string>
+  <string name="onboarding_page_saved_key_checking">Checking your saved OpenRouter connection…</string>
+  <string name="onboarding_page_saved_key_restoring">Your saved connection is still valid. Restoring the free model…</string>
+  <string name="onboarding_page_saved_key_valid">Your saved OpenRouter connection is still valid. You can restore the free model without signing in again.</string>
+  <string name="onboarding_page_saved_key_invalid">Your saved OpenRouter connection has expired or is no longer valid. Reconnect to continue.</string>
+  <string name="onboarding_page_saved_key_check_failed">We couldn\'t verify your saved OpenRouter connection. Check your network and try again.</string>
+  <string name="onboarding_page_saved_key_checking_button">Checking connection…</string>
+  <string name="onboarding_page_saved_key_restoring_button">Restoring free model…</string>
+  <string name="onboarding_page_restore_free_model_button">Restore free model</string>
+  <string name="onboarding_page_verify_saved_key_button">Verify again</string>
+  <string name="onboarding_page_reconnect_openrouter_button">Reconnect OpenRouter</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,14 +8,14 @@
   <string name="about_page_website">Website</string>
   <string name="add">Add</string>
   <string name="app_name">Miffan</string>
-  <string name="onboarding_page_title">Start chatting in a minute</string>
-  <string name="onboarding_page_description">Connect a free model now. You can change providers and models at any time.</string>
+  <string name="onboarding_page_title">Welcome to Miffan</string>
+  <string name="onboarding_page_description">No API knowledge needed. Start with a free model and change it anytime.</string>
   <string name="onboarding_page_free_badge">FREE TO START</string>
-  <string name="onboarding_page_openrouter_button">Connect OpenRouter</string>
+  <string name="onboarding_page_openrouter_button">Start chatting for free</string>
   <string name="onboarding_page_openrouter_connecting">Waiting for OpenRouter…</string>
   <string name="onboarding_page_cancel">Cancel</string>
-  <string name="onboarding_page_manual_button">Set up another provider</string>
-  <string name="onboarding_page_privacy">A secure OpenRouter page will open for sign-in and approval. Miffan never receives your password.</string>
+  <string name="onboarding_page_manual_button">Use another provider</string>
+  <string name="onboarding_page_privacy">OpenRouter will open for sign-in. Miffan never receives your password.</string>
   <string name="onboarding_page_free_limit">Uses OpenRouter’s free model router. Model availability, speed, and daily limits may vary.</string>
   <string name="onboarding_page_error_title">Could not connect</string>
   <string name="onboarding_page_retry">Try again</string>
@@ -1375,4 +1375,9 @@
   <string name="onboarding_page_restore_free_model_button">Restore free model</string>
   <string name="onboarding_page_verify_saved_key_button">Verify again</string>
   <string name="onboarding_page_reconnect_openrouter_button">Reconnect OpenRouter</string>
+  <string name="onboarding_page_recommended_badge">Recommended</string>
+  <string name="onboarding_page_free_start_title">Start for free</string>
+  <string name="onboarding_page_openrouter_brief">Provided by third-party OpenRouter, which operates independently from Miffan. No manual API key entry needed.</string>
+  <string name="onboarding_page_details_show">About OpenRouter and free limits</string>
+  <string name="onboarding_page_details_hide">Hide details</string>
 </resources>

--- a/app/src/test/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthServiceTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthServiceTest.kt
@@ -3,9 +3,11 @@ package me.ayuilos.miffan.data.ai.openrouter
 import me.ayuilos.miffan.data.datastore.OPENROUTER_FREE_MODEL_ID
 import me.ayuilos.miffan.data.datastore.OPENROUTER_PROVIDER_ID
 import me.ayuilos.miffan.data.datastore.Settings
+import me.ayuilos.miffan.data.datastore.isNotConfigured
 import me.rerere.ai.provider.OpenAIAuthType
 import me.rerere.ai.provider.ProviderSetting
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import java.time.Instant
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -57,6 +59,83 @@ class OpenRouterAuthServiceTest {
         assertEquals(OPENROUTER_FREE_MODEL_ID, connected.chatModelId)
         assertFalse(connected.enableSuggestion)
         assertTrue(provider.enabled)
+    }
+
+    @Test
+    fun `saved key can restore free model after every model is removed`() {
+        val connected = Settings().withOpenRouterConnection("saved-key")
+        val withoutModels = connected.copy(
+            providers = connected.providers.map { provider ->
+                if (provider is ProviderSetting.OpenAI && provider.id == OPENROUTER_PROVIDER_ID) {
+                    provider.copy(models = emptyList())
+                } else {
+                    provider
+                }
+            }
+        )
+
+        assertTrue(withoutModels.isNotConfigured())
+        assertEquals("saved-key", withoutModels.openRouterApiKeyOrNull())
+
+        val restored = withoutModels.withOpenRouterConnection(
+            requireNotNull(withoutModels.openRouterApiKeyOrNull())
+        )
+        val provider = restored.providers
+            .filterIsInstance<ProviderSetting.OpenAI>()
+            .single { it.id == OPENROUTER_PROVIDER_ID }
+        assertEquals(listOf("openrouter/free"), provider.models.map { it.modelId })
+        assertEquals(OPENROUTER_FREE_MODEL_ID, restored.chatModelId)
+    }
+
+    @Test
+    fun `saved key validation uses the authenticated current-key endpoint`() {
+        val request = buildOpenRouterKeyValidationRequest("saved-key")
+
+        assertEquals("https://openrouter.ai/api/v1/key", request.url.toString())
+        assertEquals("Bearer saved-key", request.header("Authorization"))
+        assertEquals("application/json", request.header("Accept"))
+    }
+
+    @Test
+    fun `key validation accepts an unexpired key and records its expiry`() {
+        val expiresAt = Instant.parse("2027-12-31T23:59:59Z")
+
+        assertEquals(
+            OpenRouterKeyValidationResult.Valid(expiresAt),
+            parseOpenRouterKeyValidation(
+                code = 200,
+                body = """{"data":{"expires_at":"2027-12-31T23:59:59Z"}}""",
+                now = Instant.parse("2027-01-01T00:00:00Z"),
+            )
+        )
+    }
+
+    @Test
+    fun `key validation rejects expired and unauthorized keys`() {
+        assertEquals(
+            OpenRouterKeyValidationResult.Invalid,
+            parseOpenRouterKeyValidation(
+                code = 200,
+                body = """{"data":{"expires_at":"2026-01-01T00:00:00Z"}}""",
+                now = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+        )
+        assertEquals(
+            OpenRouterKeyValidationResult.Invalid,
+            parseOpenRouterKeyValidation(code = 401, body = ""),
+        )
+    }
+
+    @Test
+    fun `key validation keeps transient and malformed responses retryable`() {
+        assertEquals(
+            OpenRouterKeyValidationResult.Unavailable,
+            parseOpenRouterKeyValidation(code = 500, body = ""),
+        )
+        assertEquals(
+            OpenRouterKeyValidationResult.Unavailable,
+            parseOpenRouterKeyValidation(code = 200, body = "not-json"),
+        )
     }
 
     @Test

--- a/app/src/test/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthServiceTest.kt
+++ b/app/src/test/java/me/ayuilos/miffan/data/ai/openrouter/OpenRouterAuthServiceTest.kt
@@ -4,6 +4,7 @@ import me.ayuilos.miffan.data.datastore.OPENROUTER_FREE_MODEL_ID
 import me.ayuilos.miffan.data.datastore.OPENROUTER_PROVIDER_ID
 import me.ayuilos.miffan.data.datastore.Settings
 import me.ayuilos.miffan.data.datastore.isNotConfigured
+import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.OpenAIAuthType
 import me.rerere.ai.provider.ProviderSetting
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -55,7 +56,9 @@ class OpenRouterAuthServiceTest {
         assertEquals(OpenAIAuthType.API_KEY, provider.authType)
         assertFalse(provider.useResponseApi)
         assertEquals(1, provider.models.count { it.modelId == "openrouter/free" })
-        assertEquals(OPENROUTER_FREE_MODEL_ID, provider.models.single { it.modelId == "openrouter/free" }.id)
+        val freeModel = provider.models.single { it.modelId == "openrouter/free" }
+        assertEquals(OPENROUTER_FREE_MODEL_ID, freeModel.id)
+        assertEquals(listOf(ModelAbility.TOOL, ModelAbility.REASONING), freeModel.abilities)
         assertEquals(OPENROUTER_FREE_MODEL_ID, connected.chatModelId)
         assertFalse(connected.enableSuggestion)
         assertTrue(provider.enabled)
@@ -84,6 +87,10 @@ class OpenRouterAuthServiceTest {
             .filterIsInstance<ProviderSetting.OpenAI>()
             .single { it.id == OPENROUTER_PROVIDER_ID }
         assertEquals(listOf("openrouter/free"), provider.models.map { it.modelId })
+        assertEquals(
+            listOf(ModelAbility.TOOL, ModelAbility.REASONING),
+            provider.models.single().abilities,
+        )
         assertEquals(OPENROUTER_FREE_MODEL_ID, restored.chatModelId)
     }
 

--- a/docs/releases/3.1.1.md
+++ b/docs/releases/3.1.1.md
@@ -1,0 +1,23 @@
+更新内容：
+
+### Miffan 自有改动
+
+- 优化首次设置向导的排版和文案，降低新用户的理解负担；OpenRouter 说明改为可折叠详情，并完整适配米饭 Classic 的浅色与黑夜模式。
+- 启动时验证已有 OpenRouter API Key 及其有效期；免费模型被删除后，可使用仍然有效的 Key 直接恢复，无需重复授权。
+- OpenRouter Free 模型现在默认开启工具调用和推理能力。
+
+### 同步自 RikkaHub
+
+- 本次无面向用户的改动。
+
+Updates:
+
+### Miffan changes
+
+- Refined the first-run setup layout and wording to reduce friction for new users. OpenRouter information is now shown in collapsible details, with full light and dark Miffan Classic theme support.
+- Existing OpenRouter API keys and their expiration are now validated at startup. If the free model is removed, a valid saved key can restore it without requiring authorization again.
+- OpenRouter Free now enables tool calling and reasoning capabilities by default.
+
+### Synced from RikkaHub
+
+- No user-facing changes in this release.


### PR DESCRIPTION
更新内容：

### Miffan 自有改动

- 优化首次设置向导的排版和文案，降低新用户的理解负担；OpenRouter 说明改为可折叠详情，并完整适配米饭 Classic 的浅色与黑夜模式。
- 启动时验证已有 OpenRouter API Key 及其有效期；免费模型被删除后，可使用仍然有效的 Key 直接恢复，无需重复授权。
- OpenRouter Free 模型现在默认开启工具调用和推理能力。

### 同步自 RikkaHub

- 本次无面向用户的改动。

Updates:

### Miffan changes

- Refined the first-run setup layout and wording to reduce friction for new users. OpenRouter information is now shown in collapsible details, with full light and dark Miffan Classic theme support.
- Existing OpenRouter API keys and their expiration are now validated at startup. If the free model is removed, a valid saved key can restore it without requiring authorization again.
- OpenRouter Free now enables tool calling and reasoning capabilities by default.

### Synced from RikkaHub

- No user-facing changes in this release.
