### PR TITLE
docs: professionalize GitHub issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: 报告APP Bug或者崩溃
 title: "bug: "
-labels: ["bug"]
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:
@@ -9,9 +9,9 @@ body:
         感谢你花时间提交 Bug 报告！请尽量填写完整信息以便我们复现和修复问题。
         Thanks for taking the time to report a bug! Please fill in as much detail as possible.
 
-        > **注意 | Note**
-        > 请勿提交由 AI 生成的 Issue，此类 Issue 将被直接关闭。
-        > Do not submit AI-generated issues — they will be closed without review.
+        > **提交前 | Before submitting**
+        > 请先搜索已有 Issue，并用自己的话确认问题可以复现。请勿提交 API Key、Token、Cookie、完整对话或未经脱敏的日志。
+        > Search existing issues first and confirm the problem is reproducible in your own words. Never include API keys, tokens, cookies, full conversations, or unsanitized logs.
 
   - type: textarea
     id: description
@@ -26,18 +26,35 @@ body:
       required: true
 
   - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为 | Actual Behavior
+      description: 说明实际发生了什么，以及问题出现的频率。 / Explain what actually happened and how often it occurs.
+    validations:
+      required: true
+
+  - type: textarea
     id: expected
     attributes:
       label: 期望行为 | Expected Behavior
       description: 你期望应该发生什么？ / What did you expect to happen?
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: screenshots
     attributes:
       label: 截图 | Screenshots
       description: 如有相关截图或录屏，请粘贴到此处。 / Attach relevant screenshots or screen recordings here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 | Logs
+      description: 只粘贴最小且已脱敏的相关片段；不要包含凭据或私人数据。 / Paste only the smallest relevant, sanitized excerpt; do not include credentials or private data.
+      render: text
     validations:
       required: false
 
@@ -98,3 +115,13 @@ body:
       placeholder: Xiaomi 14
     validations:
       required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: 提交前确认 | Checklist
+      options:
+        - label: 我已搜索已有 Issue，确认这不是重复报告。 / I searched existing issues and this is not a duplicate.
+          required: true
+        - label: 我已移除 API Key、Token、Cookie、私人对话和其他敏感信息。 / I removed credentials, private conversations, and other sensitive information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: 使用文档与首次配置 / Documentation & Setup
+    url: https://github.com/Ayuilos/Miffan/blob/master/README_ZH_CN.md#下载与首次配置
+    about: 使用前请先查看安装、供应商配置和数据迁移说明。 / Check setup, provider configuration, and migration guidance first.
+  - name: 安全漏洞 / Security vulnerability
+    url: https://github.com/Ayuilos/Miffan/security/policy
+    about: 请先阅读安全政策，不要在公开 Issue 中披露凭据或完整利用细节。 / Read the security policy before sharing sensitive details.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,17 +1,16 @@
 name: Feature Request
 description: 请求一个新功能
 title: "feat: "
-labels: ["enhancement"]
+labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        > **注意 | Note**
-        > 如果您想请求新功能，请先在聊天群与我讨论，否则您的功能请求可能会被直接关闭。
-        > If you want to request a new feature, please discuss it with me in the chat group first, otherwise your feature request may be closed directly.
-        >
-        > 功能请求是否被接受取决于其必要性以及对代码库的影响，并非所有请求都会被接受。
-        > Whether a feature request is accepted depends on its necessity and impact on the codebase — not all requests will be accepted.
+        请先搜索已有 Issue，并用一个 Issue 描述一个清晰、可验证的需求。功能请求是否被接受取决于用户价值、产品方向、维护成本和安全影响。
+        Search existing issues first and describe one clear, testable need per issue. Acceptance depends on user value, product direction, maintenance cost, and security impact.
+
+        请勿提交 API Key、Token、Cookie、完整对话或其他私人信息。
+        Never include API keys, tokens, cookies, full conversations, or other private information.
 
   - type: textarea
     id: description
@@ -36,3 +35,21 @@ body:
       description: 是否有其他方案可以替代这个需求？如果有，请说明。 / Are there any alternative solutions or workarounds you've considered?
     validations:
       required: false
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: 兼容性与影响 | Compatibility and Impact
+      description: 说明对现有用户、数据、权限、性能或隐私的可能影响。 / Explain possible effects on existing users, data, permissions, performance, or privacy.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: 提交前确认 | Checklist
+      options:
+        - label: 我已搜索已有 Issue，确认这不是重复请求。 / I searched existing issues and this is not a duplicate request.
+          required: true
+        - label: 我已移除凭据、私人对话和其他敏感信息。 / I removed credentials, private conversations, and other sensitive information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -1,0 +1,91 @@
+name: 使用帮助 / Configuration & Support
+description: 询问安装、配置、供应商连接或功能使用问题
+title: "support: "
+labels: ["support", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢你的提问！请先搜索已有 Issue 和 README，并用自己的话描述问题。
+        Thanks for asking! Please search existing issues and the README first, then describe the problem in your own words.
+
+        请勿粘贴 API Key、Token、Cookie、完整对话、私人链接或未经脱敏的日志。
+        Never paste API keys, tokens, cookies, full conversations, private links, or unsanitized logs.
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: 问题类型 | Topic
+      options:
+        - 安装或升级 | Installation or upgrade
+        - 供应商、模型或 API 配置 | Provider, model, or API configuration
+        - 对话、附件或工具使用 | Chat, attachments, or tools
+        - 搜索、语音或翻译 | Search, speech, or translation
+        - 工作区或 Web 访问 | Workspace or web access
+        - 其他使用问题 | Other usage question
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 你想完成什么？| Goal
+      description: 请描述使用场景、操作过程，以及目前卡住的地方。 / Describe your goal, what you tried, and where you are stuck.
+      placeholder: |
+        我想……
+        我已经尝试……
+        目前看到……
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: 错误信息或实际结果 | Error or Actual Result
+      description: 如有错误提示，请粘贴最小且已脱敏的片段。 / Include the smallest sanitized error excerpt if available.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: app-version
+    attributes:
+      label: Miffan 版本 | Miffan Version
+      placeholder: v3.0.0-rc.1
+    validations:
+      required: true
+
+  - type: input
+    id: android-version
+    attributes:
+      label: Android 版本 | Android Version
+      placeholder: Android 14
+    validations:
+      required: true
+
+  - type: input
+    id: provider-model
+    attributes:
+      label: 供应商与模型 | Provider and Model
+      description: 如果与问题相关，请填写名称，不要填写密钥或账号信息。 / If relevant, provide names only; never include credentials.
+      placeholder: OpenAI · gpt-4o
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 补充信息 | Additional Context
+      description: 可附截图、录屏或相关链接；请确认其中没有敏感信息。 / Add screenshots, recordings, or links after checking for sensitive data.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: 提交前确认 | Checklist
+      options:
+        - label: 我已搜索已有 Issue 和文档，确认这不是重复问题。 / I searched existing issues and documentation and this is not a duplicate.
+          required: true
+        - label: 我已移除 API Key、Token、Cookie、私人对话和其他敏感信息。 / I removed credentials, private conversations, and other sensitive information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -29,7 +29,7 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: 你想完成什么？| Goal
+      label: 问题描述 | Problem Description
       description: 请描述使用场景、操作过程，以及目前卡住的地方。 / Describe your goal, what you tried, and where you are stuck.
       placeholder: |
         我想……

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to RikkaHub
+# Contributing to Miffan
 
 Thank you for your interest in contributing to RikkaHub. To keep reviews focused and the project
 maintainable, please read the following rules before opening a pull request.
@@ -29,6 +29,22 @@ review.
 
 If a fix requires extensive changes, discuss it in the related issue first. The maintainers may ask
 you to reduce the scope or split the work into multiple independent pull requests.
+
+## Issue standards
+
+Please read the [Issue guidelines](docs/ISSUE_GUIDELINES.md) before opening an issue. Use the
+closest form, search for duplicates first, keep one topic per issue, and include enough version,
+environment, and reproduction information for the maintainer to verify it. Never post API keys,
+tokens, cookies, private conversations, or unsanitized logs.
+
+The available forms are:
+
+- Bug Report for reproducible failures, crashes, and regressions
+- Feature Request for a proposed product improvement
+- Configuration & Support for setup and usage questions
+
+Blank issues are disabled. Issues may be closed or redirected when they lack the information
+needed for triage, duplicate an existing report, or fall outside the project's scope.
 
 ## What we accept
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Upstream copyright and attribution are retained as required by the license. Miff
 
 Issues and pull requests are welcome. For substantial changes, open an issue first so the product direction and implementation scope can be discussed. When reporting a bug, include the Miffan version, Android version, provider type, and reproducible steps, but remove API keys and private conversation content.
 
-Before submitting a pull request, please read the [contribution guidelines](CONTRIBUTING.md).
+Before opening an issue, please read the [Issue guidelines](docs/ISSUE_GUIDELINES.md). Before submitting a pull request, please read the [contribution guidelines](CONTRIBUTING.md).
 
 ## License
 

--- a/README_ZH_CN.md
+++ b/README_ZH_CN.md
@@ -167,6 +167,8 @@ Miffan 最初源自 [RikkaHub](https://github.com/rikkahub/rikkahub) 的社区�
 
 欢迎提交 Issue 与 Pull Request。对于较大的改动，建议先创建 Issue 讨论产品方向和实现范围。报告问题时请附上 Miffan 版本、Android 版本、供应商类型和复现步骤，并移除 API Key 与私人对话内容。
 
+创建 Issue 前请先阅读 [Issue 提交规范](docs/ISSUE_GUIDELINES.md)，并选择最匹配的模板。
+
 ## 许可证
 
 Miffan 使用 [GNU Affero General Public License v3.0](LICENSE) 发布。

--- a/docs/ISSUE_GUIDELINES.md
+++ b/docs/ISSUE_GUIDELINES.md
@@ -1,0 +1,41 @@
+# Issue 提交规范 / Issue Guidelines
+
+Issue 是 Miffan 的公开协作记录。清晰、可复现、经过脱敏的报告会更容易被定位和处理。
+Issues are the project's public collaboration record. Clear, reproducible, and sanitized reports are easier to triage.
+
+## 提交前 / Before opening an issue
+
+1. 搜索已有 Issue、README 和相关文档，避免重复。
+   Search existing issues, the README, and relevant documentation first.
+2. 一个 Issue 只讨论一个问题或一个需求。
+   Keep one problem or request per issue.
+3. 确认使用的是较新的 Miffan 版本，并记录 Android 版本、设备型号和相关供应商/模型。
+   Confirm the issue on a recent Miffan build and record Android version, device model, and relevant provider/model.
+4. 删除 API Key、Token、Cookie、私人对话、文件内容、内网地址和未经脱敏的日志。
+   Remove API keys, tokens, cookies, private conversations, file contents, internal URLs, and unsanitized logs.
+5. 选择最匹配的 Issue Form；空白 Issue 默认关闭。
+   Choose the closest Issue Form; blank issues are disabled by default.
+
+## 哪个模板 / Which form
+
+| 模板 | 适用范围 |
+| --- | --- |
+| Bug Report | 可复现的崩溃、错误、回归或功能失效 |
+| Feature Request | 新能力、改进或产品建议 |
+| 使用帮助 / Configuration & Support | 安装、配置、连接和使用问题 |
+
+## 标题与内容 / Titles and content
+
+模板会自动添加 `bug:`、`feat:` 或 `support:` 前缀。标题应简洁说明结果，例如 `bug: Gemini 流式回复在后台暂停`，不要只写“打不开”或“有问题”。
+Forms add the `bug:`, `feat:`, or `support:` prefix automatically. Keep titles outcome-focused, such as `bug: Gemini streaming pauses in background`, rather than “doesn't work”.
+
+Bug 报告至少应包含复现步骤、期望行为、实际行为、版本、Android 版本和设备型号。功能请求应说明要解决的问题、使用场景和考虑过的替代方案。使用帮助应说明目标、已尝试的操作和最小错误信息。
+Bug reports should include reproduction steps, expected and actual behavior, versions, and device model. Feature requests should explain the problem, use case, and alternatives. Support requests should explain the goal, attempted steps, and the smallest relevant error.
+
+## 处理方式 / Triage
+
+维护者会根据可复现性、影响范围、产品方向、维护成本和安全风险进行分类。可能的结果包括补充信息、标记重复、暂不处理、修复后关闭或转为讨论。Issue 是异步协作渠道，不承诺固定响应时间；请在原 Issue 中补充信息，避免重复开帖。
+Maintainers triage based on reproducibility, impact, product direction, maintenance cost, and security risk. An issue may be asked for more information, marked as duplicate, deferred, fixed and closed, or redirected to discussion. Issues are asynchronous; no fixed response time is promised. Add follow-ups to the original issue instead of opening duplicates.
+
+安全问题请先阅读 [安全政策](../SECURITY.md)，不要在公开 Issue 中披露完整利用细节或敏感数据。
+For security concerns, read the [security policy](../SECURITY.md) first and do not disclose full exploit details or sensitive data in a public issue.


### PR DESCRIPTION
## Summary

- add structured Bug, Feature, and Configuration & Support issue forms
- document submission, privacy, and triage standards
- add bilingual setup and security guidance
- apply consistent bug, enhancement, support, and needs-triage labels

## Verification

- local YAML parsing passed
- GitHub Issues is enabled on the repository
- support form includes the marker recognized by the existing blank-issue workflow

Please review and merge when ready.